### PR TITLE
fix: 修复远程故障转移详情点击崩溃

### DIFF
--- a/app/src/main/kotlin/com/nekobot/app/data/model/FailoverModels.kt
+++ b/app/src/main/kotlin/com/nekobot/app/data/model/FailoverModels.kt
@@ -23,8 +23,11 @@ data class FailoverHealth(
 
 /** 模型 token 用量快照，用于显示日/周用量百分比 */
 data class FailoverTokenUsage(
-    @SerializedName("daily_tokens") val dailyTokens: Long = 0,
-    @SerializedName("weekly_tokens") val weeklyTokens: Long = 0,
+    // 本地模式使用 daily_tokens/weekly_tokens；远程后端使用 today_total/weekly_total。
+    @SerializedName(value = "daily_tokens", alternate = ["today_total"])
+    val dailyTokens: Long = 0,
+    @SerializedName(value = "weekly_tokens", alternate = ["weekly_total"])
+    val weeklyTokens: Long = 0,
     @SerializedName("daily_limit") val dailyLimit: Long = 0,
     @SerializedName("weekly_limit") val weeklyLimit: Long = 0
 ) {
@@ -51,6 +54,8 @@ data class FailoverModelDetail(
     val purpose: String = "",
     val enabled: Boolean = true,
     val health: FailoverHealth = FailoverHealth(),
+    // 本地模式字段名为 usage；远程 Nekobot 后端字段名为 token_usage。
+    @SerializedName(value = "usage", alternate = ["token_usage"])
     val usage: FailoverTokenUsage = FailoverTokenUsage(),
     @SerializedName("token_limit_daily") val tokenLimitDaily: Long = 0,
     @SerializedName("token_limit_weekly") val tokenLimitWeekly: Long = 0,

--- a/app/src/test/kotlin/com/nekobot/app/data/model/FailoverModelsTest.kt
+++ b/app/src/test/kotlin/com/nekobot/app/data/model/FailoverModelsTest.kt
@@ -1,0 +1,63 @@
+package com.nekobot.app.data.model
+
+import com.google.gson.Gson
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+
+class FailoverModelsTest {
+
+    private val gson = Gson()
+
+    @Test
+    fun remoteFailoverDetail_deserializesTokenUsageAliases() {
+        val json = """
+            {
+              "model_id": "model-1",
+              "name": "Remote model",
+              "model": "gpt-test",
+              "health": {
+                "available": true,
+                "daily_failures": 1,
+                "consecutive_failures": 2
+              },
+              "token_limit_daily": 1000,
+              "token_limit_weekly": 5000,
+              "token_usage": {
+                "today_total": 120,
+                "weekly_total": 640
+              }
+            }
+        """.trimIndent()
+
+        val detail = gson.fromJson(json, FailoverModelDetail::class.java)
+
+        assertNotNull(detail.usage)
+        assertEquals(120L, detail.usage.dailyTokens)
+        assertEquals(640L, detail.usage.weeklyTokens)
+        assertEquals(1000L, detail.tokenLimitDaily)
+        assertEquals(5000L, detail.tokenLimitWeekly)
+    }
+
+    @Test
+    fun localFailoverDetail_keepsExistingUsageFieldNames() {
+        val json = """
+            {
+              "model_id": "model-2",
+              "usage": {
+                "daily_tokens": 25,
+                "weekly_tokens": 100,
+                "daily_limit": 500,
+                "weekly_limit": 2000
+              }
+            }
+        """.trimIndent()
+
+        val detail = gson.fromJson(json, FailoverModelDetail::class.java)
+
+        assertEquals(25L, detail.usage.dailyTokens)
+        assertEquals(100L, detail.usage.weeklyTokens)
+        assertEquals(500L, detail.usage.dailyLimit)
+        assertEquals(2000L, detail.usage.weeklyLimit)
+    }
+}


### PR DESCRIPTION
## 问题

远程模式点击故障转移队列中的模型卡片后，详情弹窗在首次组合时崩溃。

## 根因

Android 类型模型期望详情接口返回：

- `usage`
- `daily_tokens`
- `weekly_tokens`

Nekobot 远程后端实际返回：

- `token_usage`
- `today_total`
- `weekly_total`

Gson 未找到 `usage` 字段时，会使 Kotlin 非空属性在运行时成为 `null`，随后 UI 访问 `detail.usage.dailyLimit` 触发空指针异常。本地模式由 Android 直接组装 `usage`，所以不受影响。

## 修改

- 为 `FailoverModelDetail.usage` 增加 `token_usage` 兼容别名。
- 为日/周 token 用量增加 `today_total`、`weekly_total` 兼容别名。
- 保留本地模式原有字段名，确保向后兼容。
- 增加 Gson 反序列化单测，覆盖远程和本地两种响应结构。

## 验证

- 已核对分支相对 `main` 仅包含数据模型兼容修改和回归测试。
- 当前环境无法执行 Gradle，因此测试尚未实际运行。