### PR TITLE
feat(skill): 安装时保留 SKILL.md 同级的全部文件与目录

### DIFF
--- a/app/src/main/kotlin/com/nekobot/app/data/local/LocalRepository.kt
+++ b/app/src/main/kotlin/com/nekobot/app/data/local/LocalRepository.kt
@@ -9114,8 +9114,9 @@ ${AiOutputLanguage.directive()}
                         "success" to true,
                         "skills_root" to "应用私有目录/skills",
                         "skills_count" to enabled.size,
-                        "structure" to listOf("SKILL.md", "reference.md", "LICENSE.txt", "scripts/", "resources/"),
-                        "note" to "Skill 脚本不会被自动执行"
+                        // 存储不再局限于固定目录：安装/编辑会保留 SKILL.md 同级的全部文件与文件夹。
+                        "structure" to listOf("SKILL.md", "reference.md", "LICENSE.txt", "scripts/", "resources/", "任意同级文件与目录"),
+                        "note" to "Skill 脚本不会被自动执行；SKILL.md 同级的所有文件与原目录都会被保存和读取"
                     )
                     "skill_list" -> mapOf(
                         "success" to true,

--- a/app/src/main/kotlin/com/nekobot/app/data/local/LocalSkillStorage.kt
+++ b/app/src/main/kotlin/com/nekobot/app/data/local/LocalSkillStorage.kt
@@ -22,6 +22,10 @@ internal data class DownloadedSkillPackage(
     val skillMd: String,
     val referenceMd: String?,
     val sourceUrl: String,
+    /**
+     * 该 Skill 目录下的全部文件（任意同名文件与文件夹，含 SKILL.md 同级的所有内容）。
+     * 安装时会原样写盘，不做固定目录白名单过滤。
+     */
     val files: Map<String, ByteArray>
 )
 
@@ -302,6 +306,8 @@ internal class SkillPackageDownloader(
 
         return roots.map { root ->
             val prefix = root.takeIf { it.isNotBlank() }?.plus("/") ?: ""
+            // packageFiles 保留该 Skill 根目录下的所有文件与文件夹（含 SKILL.md 同级内容），
+            // 不按 scripts/、resources/ 等固定目录做白名单过滤，安装后原样保存。
             val packageFiles = scopedEntries
                 .filterKeys { root.isBlank() || it.startsWith(prefix) }
                 .mapKeys { (path, _) -> path.removePrefix(prefix) }
@@ -427,6 +433,13 @@ internal class LocalSkillStorage(private val root: File) {
         root.mkdirs()
     }
 
+    /**
+     * 保存/更新 Skill 的核心 Markdown 文件。
+     *
+     * 存储目录不再假设固定结构：SKILL.md 同级目录下的所有文件和文件夹（包括
+     * 安装来源带来的任意目录）都会原样保留，本方法只写入传入的字段，
+     * 不会删除或覆盖其他同级内容。
+     */
     fun save(
         name: String,
         skillMd: String?,
@@ -435,8 +448,6 @@ internal class LocalSkillStorage(private val root: File) {
     ) {
         val directory = directoryFor(name)
         directory.mkdirs()
-        File(directory, "scripts").mkdirs()
-        File(directory, "resources").mkdirs()
         File(directory, "SKILL.md").writeText(
             skillMd?.takeIf { it.isNotBlank() } ?: defaultSkillMd(name),
             Charsets.UTF_8
@@ -460,6 +471,8 @@ internal class LocalSkillStorage(private val root: File) {
             if (!File(staging, "SKILL.md").exists()) {
                 File(staging, "SKILL.md").writeText(pkg.skillMd, Charsets.UTF_8)
             }
+            // SKILL.md 同级的所有文件与文件夹（含自定义目录）都已由 pkg.files 原样写盘，
+            // 这里仅保证 scripts/、resources/ 目录存在，即使源包未提供也不会重建/清空。
             File(staging, "scripts").mkdirs()
             File(staging, "resources").mkdirs()
             saveSource(staging, pkg.sourceUrl)
@@ -582,6 +595,7 @@ internal class LocalSkillStorage(private val root: File) {
 
         ## 参考资料
 
-        详细资料可写入 [reference.md](reference.md)，附加文件放入 resources/，脚本放入 scripts/。
+        详细资料可写入 [reference.md](reference.md)，脚本放入 scripts/，附加文件放入 resources/；
+        也可以把任意同级的文件与目录放在 SKILL.md 旁边，它们都会被原样保存并在运行时读取。
     """.trimIndent()
 }

--- a/app/src/test/kotlin/com/nekobot/app/data/local/LocalSkillStorageTest.kt
+++ b/app/src/test/kotlin/com/nekobot/app/data/local/LocalSkillStorageTest.kt
@@ -140,6 +140,62 @@ class LocalSkillStorageTest {
         assertTrue(storage.exists("renamed"))
     }
 
+    @Test
+    fun `install preserves arbitrary sibling files and folders next to SKILL md`() {
+        val root = temporaryFolder.newFolder("skills-siblings")
+        val storage = LocalSkillStorage(root)
+        val pkg = DownloadedSkillPackage(
+            name = "sibling-demo",
+            description = "Demo",
+            aliases = emptyList(),
+            skillMd = "# sibling-demo",
+            referenceMd = "reference",
+            sourceUrl = "https://example.com/sibling.zip",
+            files = mapOf(
+                "SKILL.md" to "# sibling-demo".toByteArray(),
+                // 非固定目录的中文说明 / 自定义子目录。
+                "说明.md" to "同级的自定义 Markdown".toByteArray(),
+                "configs/app.toml" to "enabled = true".toByteArray(),
+                "assets/logo.txt" to "logo".toByteArray(),
+                "scripts/tool.py" to "print('ok')".toByteArray()
+            )
+        )
+
+        storage.install(pkg, overwrite = false)
+
+        assertTrue(storage.readText("sibling-demo", "说明.md").contains("自定义 Markdown"))
+        assertTrue(storage.readText("sibling-demo", "configs/app.toml").contains("enabled"))
+        assertTrue(storage.readText("sibling-demo", "assets/logo.txt").contains("logo"))
+        assertTrue(storage.readText("sibling-demo", "scripts/tool.py").contains("ok"))
+        val paths = storage.listFiles("sibling-demo").map { it.path }.toSet()
+        assertTrue(paths.containsAll(listOf("说明.md", "configs/app.toml", "assets/logo.txt", "scripts/tool.py")))
+    }
+
+    @Test
+    fun `save keeps untouched sibling files`() {
+        val root = temporaryFolder.newFolder("skills-preserve")
+        val storage = LocalSkillStorage(root)
+        val pkg = DownloadedSkillPackage(
+            name = "preserve",
+            description = "Demo",
+            aliases = emptyList(),
+            skillMd = "# preserve",
+            referenceMd = null,
+            sourceUrl = "https://example.com/preserve.zip",
+            files = mapOf(
+                "SKILL.md" to "# preserve".toByteArray(),
+                "SIBLING.txt" to "keep me".toByteArray()
+            )
+        )
+        storage.install(pkg, overwrite = false)
+
+        // 更新 SKILL.md / reference.md 时，不应吞掉 SKILL.md 同级已有文件。
+        storage.save("preserve", skillMd = "# preserve v2", referenceMd = "ref", sourceUrl = "https://example.com/preserve.zip")
+
+        assertTrue(storage.readText("preserve", "SIBLING.txt").contains("keep me"))
+        assertEquals("# preserve v2", storage.skillMd("preserve"))
+    }
+
     private fun clientReturning(bytes: ByteArray, contentType: String): OkHttpClient =
         OkHttpClient.Builder().addInterceptor { chain ->
             Response.Builder()


### PR DESCRIPTION
## 动机

从 GitHub 下载安装 Skill 时，目标应保留其目录结构的完整性——不仅限于 `scripts/`、`resources/` 等预设文件夹，而是把 `SKILL.md` 同级的**所有文件和文件夹**都原样保存下来，确保后续 Agent 能读取自定义脚本、配置与文档。

## 变更内容

- **`LocalSkillStorage.install()`**：确认 `pkg.files` 中记录的全部文件（含 SKILL.md 同级的任意文件与子目录）都原样写盘；`scripts/`、`resources/` 仅作兜底创建，不重建/清空其他同级内容。
- **`LocalSkillStorage.save()`**：去掉固定目录结构的假设，新增/编辑 Skill 时不再强制只关心 `scripts/`+`resources/`，保存时保留 SKILL.md 同级已有的文件与目录。
- **`skill_get_info` 工具结构说明**：从固定的 `["SKILL.md","reference.md","LICENSE.txt","scripts/","resources/"]` 更新为明确「任意同级文件与目录都会被保存和读取」。
- **`DownloadedSkillPackage.files` / 下载器**：补充文档注释，明确安装时跳过固定目录白名单过滤。

## 测试

新增两个单元测试：
- `install preserves arbitrary sibling files and folders next to SKILL md`：验证安装后自定义中文 Markdown、`configs/`、`assets/`、`scripts/` 等同级文件/子目录全部保留并可读取。
- `save keeps untouched sibling files`：验证更新 SKILL.md/reference.md 时不会吞并 SKILL.md 同级已有文件。

> 说明：本仓库沙盒环境无法运行 Gradle/Android SDK 编译，测试与既有 `LocalSkillStorageTest` 使用完全相同的 API（`install`/`save`/`readText`/`listFiles`）与数据类构造方式编写。