### PR TITLE
fix(chat): 消息数不足但上下文占用超阈值时也允许手动压缩

### DIFF
--- a/app/src/main/kotlin/com/nekobot/app/data/local/LocalRepository.kt
+++ b/app/src/main/kotlin/com/nekobot/app/data/local/LocalRepository.kt
@@ -175,6 +175,9 @@ private const val AGENT_SUMMARY_INPUT_OVERHEAD_TOKENS = 1_024
 private const val AGENT_CONTEXT_MESSAGE_OVERHEAD_TOKENS = 8
 private const val DEFAULT_AGENT_CONTEXT_TOKENS = 100_000
 
+/** 手动压缩的兜底阈值：消息数不足时，上下文占用超过该比例也允许压缩。 */
+internal const val MANUAL_COMPRESSION_CONTEXT_RATIO = 0.10f
+
 /** 兼容旧版 Agent 会话中未写入 source 的历史摘要。 */
 internal fun LocalMessageEntity.isAgentContextSummary(): Boolean =
     role.equals("system", ignoreCase = true) && (
@@ -201,6 +204,31 @@ internal fun List<LocalMessageEntity>.agentContextWindow(): List<LocalMessageEnt
         add(summary)
         addAll(this@agentContextWindow.drop(boundaryIndex + 1).filterNot { it.isAgentContextSummary() })
     }
+}
+
+/**
+ * 计算手动压缩应保留的最近消息数。
+ *
+ * 消息数充足（超过 [keepRecent] + [margin]）时按 [keepRecent] 保留；消息数不足时，
+ * 只有上下文占用比例超过 [MANUAL_COMPRESSION_CONTEXT_RATIO]（少量超长消息把上下文顶高）
+ * 才缩小保留窗口继续压缩，避免"对话过短"的提示掩盖高上下文占用。
+ *
+ * @param messageCount 参与压缩判定的消息数（普通会话为上下文消息总数，Agent 会话为窗口内非 system 消息数）
+ * @param keepRecent 默认保留的最近消息数
+ * @param contextUsageRatio 当前上下文占用比例（0-1），无法估算时传 0
+ * @param margin 消息数充足判定在 [keepRecent] 之外要求的额外余量
+ * @return 实际保留的最近消息数；-1 表示无需压缩
+ */
+internal fun resolveManualCompressionKeepCount(
+    messageCount: Int,
+    keepRecent: Int,
+    contextUsageRatio: Float,
+    margin: Int
+): Int {
+    if (messageCount > keepRecent + margin) return keepRecent
+    if (contextUsageRatio <= MANUAL_COMPRESSION_CONTEXT_RATIO || messageCount < 2) return -1
+    // 保留最近一半（至少 2 条），并确保至少有 1 条消息可被压缩。
+    return minOf(keepRecent, maxOf(2, messageCount / 2)).coerceIn(1, messageCount - 1)
 }
 
 /** UI 只识别新版摘要，旧摘要会在下一次 Agent 压缩时自动迁移。 */
@@ -6037,12 +6065,23 @@ class LocalRepository(
         }
 
         val messages = listAiContextMessages(sessionId)
-        if (messages.size <= keepRecent + 2) {
+        // 占用比例与聊天页上下文圆环同一口径：sessionContextTokenUsage / 激活模型上下文窗口。
+        val maxContextTokens = aiModelDao.getActive()?.maxContextLength?.takeIf { it > 0 }
+        val usageRatio = maxContextTokens
+            ?.let { sessionContextTokenUsage(sessionId).toFloat() / it.toFloat() }
+            ?: 0f
+        val keepCount = resolveManualCompressionKeepCount(
+            messageCount = messages.size,
+            keepRecent = keepRecent,
+            contextUsageRatio = usageRatio,
+            margin = 2
+        )
+        if (keepCount < 0) {
             return@withContext ContextCompressionResult(compressed = false)
         }
 
-        val toCompress = messages.dropLast(keepRecent)
-        val toKeep = messages.takeLast(keepRecent)
+        val toCompress = messages.dropLast(keepCount)
+        val toKeep = messages.takeLast(keepCount)
 
         // 构造摘要请求
         val dialogText = toCompress.joinToString("\n") { m ->
@@ -6152,7 +6191,8 @@ class LocalRepository(
     ): ContextCompressionResult {
         val messages = listAiContextMessages(sessionId)
         val currentSummary = messages.asReversed().firstOrNull(LocalMessageEntity::isAgentContextSummary)
-        val activeNonSystemMessages = messages.agentContextWindow()
+        val contextWindow = messages.agentContextWindow()
+        val activeNonSystemMessages = contextWindow
             .filterNot { it.role.equals("system", ignoreCase = true) }
         if (activeNonSystemMessages.isEmpty()) return ContextCompressionResult(compressed = false)
 
@@ -6163,7 +6203,22 @@ class LocalRepository(
         val retainedMessages = if (automatic) {
             retainAgentMessagesWithinLimit(activeNonSystemMessages, maxContextTokens)
         } else {
-            activeNonSystemMessages.takeLast(keepRecent.coerceAtLeast(1))
+            val baseKeep = keepRecent.coerceAtLeast(1)
+            // 占用比例与 Agent 自动压缩、聊天页上下文圆环同一口径：
+            // 统计窗口内非 system 消息与压缩摘要的估算 token。
+            val usageRatio = contextWindow
+                .filter { !it.role.equals("system", ignoreCase = true) || it.isAgentContextSummary() }
+                .sumOf { it.agentContextTokenCount() }
+                .toFloat() / maxContextTokens.toFloat()
+            val keepCount = resolveManualCompressionKeepCount(
+                messageCount = activeNonSystemMessages.size,
+                keepRecent = baseKeep,
+                contextUsageRatio = usageRatio,
+                margin = 0
+            )
+            // 消息数不足 keepRecent 时，只有占用超阈值才缩小保留窗口继续压缩，
+            // 否则维持原窗口，由下方 toCompress 判定并返回"无需压缩"。
+            activeNonSystemMessages.takeLast(if (keepCount < 0) baseKeep else keepCount)
         }
         val retainedIds = retainedMessages.mapTo(hashSetOf()) { it.id }
         val toCompress = activeNonSystemMessages.filterNot { it.id in retainedIds }

--- a/app/src/test/kotlin/com/nekobot/app/data/local/ManualCompressionKeepCountTest.kt
+++ b/app/src/test/kotlin/com/nekobot/app/data/local/ManualCompressionKeepCountTest.kt
@@ -1,0 +1,57 @@
+package com.nekobot.app.data.local
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * 手动压缩保留窗口的判定逻辑。
+ *
+ * 覆盖需求场景：会话消息数少，但上下文占用已超过 10% 时也允许压缩
+ * （缩小保留窗口，保证至少有 1 条消息可被压缩）。
+ */
+class ManualCompressionKeepCountTest {
+
+    @Test
+    fun keepsDefaultWindowWhenMessageCountIsSufficient() {
+        // 普通会话：超过 keepRecent + 2 即按原窗口压缩
+        assertEquals(10, resolveManualCompressionKeepCount(13, 10, 0f, margin = 2))
+        assertEquals(10, resolveManualCompressionKeepCount(50, 10, 0.9f, margin = 2))
+        // Agent 会话：超过 keepRecent 即按原窗口压缩
+        assertEquals(10, resolveManualCompressionKeepCount(11, 10, 0f, margin = 0))
+    }
+
+    @Test
+    fun refusesCompressionWhenMessagesAreFewAndUsageIsLow() {
+        assertEquals(-1, resolveManualCompressionKeepCount(5, 10, 0.05f, margin = 2))
+        // 恰好等于 10% 不算"超过"
+        assertEquals(-1, resolveManualCompressionKeepCount(5, 10, 0.10f, margin = 2))
+        assertEquals(-1, resolveManualCompressionKeepCount(8, 10, 0.02f, margin = 0))
+    }
+
+    @Test
+    fun compressesFewMessagesWhenUsageExceedsThreshold() {
+        // 5 条消息：保留最近 2 条，压缩前 3 条
+        assertEquals(2, resolveManualCompressionKeepCount(5, 10, 0.2f, margin = 2))
+        // 2 条消息：保留 1 条，压缩 1 条
+        assertEquals(1, resolveManualCompressionKeepCount(2, 10, 0.5f, margin = 2))
+        // 3 条消息：保留 2 条，压缩 1 条
+        assertEquals(2, resolveManualCompressionKeepCount(3, 10, 0.3f, margin = 0))
+        // 12 条消息（普通会话原规则会拒绝）：占用超阈值时保留一半
+        assertEquals(6, resolveManualCompressionKeepCount(12, 10, 0.3f, margin = 2))
+    }
+
+    @Test
+    fun cannotCompressSingleMessageSession() {
+        assertEquals(-1, resolveManualCompressionKeepCount(1, 10, 0.9f, margin = 2))
+        assertEquals(-1, resolveManualCompressionKeepCount(0, 10, 0.9f, margin = 2))
+        assertEquals(-1, resolveManualCompressionKeepCount(1, 10, 0.9f, margin = 0))
+    }
+
+    @Test
+    fun shrunkWindowNeverExceedsDefaultKeepRecent() {
+        // 消息数在 (keepRecent, keepRecent + margin] 区间且占用超阈值时，
+        // 缩小后的窗口不能大于 keepRecent
+        assertEquals(5, resolveManualCompressionKeepCount(11, 10, 0.5f, margin = 2))
+        assertEquals(10, resolveManualCompressionKeepCount(30, 10, 0.5f, margin = 2))
+    }
+}


### PR DESCRIPTION
## 问题

聊天页 **+ 号菜单的压缩按钮**在会话消息数少时始终无法压缩：

- 普通会话：`compressContext` 要求消息数 > `keepRecent + 2`（≥13 条），否则直接返回 `compressed = false`，界面提示「对话过短，暂无可压缩内容」。
- Agent 会话：手动压缩固定保留最近 10 条非 system 消息，消息数 ≤ 10 时无可压缩内容，同样返回无需压缩。

但消息数少不代表上下文占用低——少量超长消息（长文粘贴、大工具输出等）同样会把上下文占用顶高，此时用户手动点击压缩却被拒绝。

## 方案

抽出纯函数 `resolveManualCompressionKeepCount` 统一普通会话与 Agent 会话两条路径的保留窗口判定：

- **消息数充足**（超过 `keepRecent + margin`）：维持原行为，按 `keepRecent` 保留。
- **消息数不足**：只有**上下文占用比例 > 10%**（`MANUAL_COMPRESSION_CONTEXT_RATIO = 0.10f`）才缩小保留窗口继续压缩——保留最近一半（至少 2 条），并保证至少有 1 条消息可被压缩；占用未超阈值时维持原「无需压缩」行为。
- 占用比例口径与聊天页上下文圆环一致：
  - 普通会话：`sessionContextTokenUsage(sessionId) / 激活模型 maxContextLength`；
  - Agent 会话：压缩窗口内非 system 消息 + 压缩摘要的估算 token / `maxContextTokens`（与自动压缩触发条件同口径）。

## 测试

- 新增 `ManualCompressionKeepCountTest`（15 个断言）：消息数充足/不足、占用等于与超过 10% 的边界、单条消息会话、收缩窗口不超过默认窗口等。
- 判定逻辑已用等价脚本逐例验证全部通过；`testDebugUnitTest lintDebug assembleDebug` 由 CI 验证。

## 影响

- 消息数多或占用低的会话行为完全不变。
- 消息数少但占用 > 10% 的会话现在可以手动压缩：普通会话压缩早期消息并归档，Agent 会话只前移摘要边界，均复用既有压缩管线。