### PR TITLE
feat(chat): /goal、/spec 命令以彩色胶囊显示并同步用户气泡

### DIFF
--- a/app/src/main/kotlin/com/nekobot/app/ui/screens/chat/ChatScreen.kt
+++ b/app/src/main/kotlin/com/nekobot/app/ui/screens/chat/ChatScreen.kt
@@ -2748,6 +2748,14 @@ private fun MessageBubble(
 ) {
     val isUser = message.isUser
     val isLocalCommand = message.isLocalCommandMessage()
+    // 命令胶囊：/goal、/spec 用户命令在气泡内显示为彩色胶囊 + 本地化标签，
+    // 气泡底色同步切换为命令专属渐变（仅单段文本消息应用，避免与多段气泡样式冲突）
+    val commandCapsule = remember(message.id, message.content, isUser) {
+        if (isUser) matchCommandCapsule(message.content.orEmpty()) else null
+    }
+    val commandCapsuleBrush = commandCapsule?.let {
+        Brush.linearGradient(listOf(it.kind.startColor, it.kind.endColor))
+    }
     // 用户气泡基色：若设置了主题色覆盖则跟随主题，否则使用默认紫色
     val userBubble = ServiceContainer.prefs.themeColorOverride?.let { parseHexColor(it) }
         ?: if (isSystemInDarkTheme()) BubbleUser else BubbleUserLight
@@ -2925,6 +2933,7 @@ private fun MessageBubble(
                 Spacer(Modifier.height(6.dp))
             }
             // 多段气泡：每段一个气泡，段间小间距
+            val commandStyle = commandCapsule?.takeIf { segments.size == 1 }
             segments.forEachIndexed { idx, segment ->
                 val isFirst = idx == 0
                 val isLast = idx == segments.lastIndex
@@ -2946,6 +2955,8 @@ private fun MessageBubble(
                         .then(if (isUser && !segHasUserImage) Modifier.shadow(2.dp, segShape, clip = false) else Modifier)
                         .then(
                             when {
+                                isUser && commandStyle != null && !segHasUserImage ->
+                                    Modifier.background(brush = commandCapsuleBrush!!, shape = segShape)
                                 isUser && !segHasUserImage ->
                                     Modifier.background(brush = userBrush, shape = segShape)
                                 !isUser ->
@@ -3016,6 +3027,34 @@ private fun MessageBubble(
                             chatMode = true,
                             processParens = !isUser
                         )
+                    } else if (commandStyle != null && isUser) {
+                        // 命令消息（/goal、/spec）：彩色胶囊 + 其余参数文本
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            CommandCapsuleChip(kind = commandStyle.kind, translucent = true)
+                            val rest = segment.removePrefix(commandStyle.token).trim()
+                            if (rest.isNotEmpty()) {
+                                Spacer(Modifier.width(8.dp))
+                                if (useSafePlainText) {
+                                    SafePlainMessageText(
+                                        text = rest,
+                                        color = textColor,
+                                        modifier = Modifier.weight(1f)
+                                    )
+                                } else {
+                                    MarkdownText(
+                                        text = rest,
+                                        modifier = Modifier.weight(1f),
+                                        color = textColor,
+                                        style = MaterialTheme.typography.bodyMedium,
+                                        chatMode = true,
+                                        processParens = false
+                                    )
+                                }
+                            }
+                        }
                     } else {
                         // 文本内容：用 Markdown 渲染
                         // 用户气泡：宽度跟随实际内容（短消息不撑满）；AI 气泡：填满最大宽度
@@ -5422,6 +5461,8 @@ private fun ChatInputBar(
 ) {
     var panelExpanded by rememberSaveable { mutableStateOf(false) }
     var inputExpanded by rememberSaveable { mutableStateOf(false) }
+    // 命令胶囊：/goal、/spec 前缀显示为彩色胶囊（备用输入栏与 ModernChatComposer 保持一致）
+    val commandCapsule = remember(input) { matchCommandCapsule(input) }
     // 字符数与 token 估算：中文字符约 1 token/字，英文约 0.25 token/字符
     val charCount = input.length
     val chineseCount = input.count { it.code in 0x4E00..0x9FFF }
@@ -5635,7 +5676,14 @@ private fun ChatInputBar(
                         placeholder = { Text(if (sending) stringResource(R.string.chat_ai_thinking) else stringResource(R.string.chat_input_placeholder)) },
                         enabled = !sending,
                         maxLines = 5,
-                        shape = RoundedCornerShape(24.dp)
+                        shape = RoundedCornerShape(24.dp),
+                        visualTransformation = commandCapsuleVisualTransformation(),
+                        prefix = {
+                            if (commandCapsule != null) {
+                                CommandCapsuleChip(kind = commandCapsule.kind)
+                                Spacer(Modifier.width(6.dp))
+                            }
+                        }
                     )
                     Spacer(Modifier.width(8.dp))
                     val showSend = sending || input.isNotBlank()

--- a/app/src/main/kotlin/com/nekobot/app/ui/screens/chat/CommandCapsule.kt
+++ b/app/src/main/kotlin/com/nekobot/app/ui/screens/chat/CommandCapsule.kt
@@ -2,15 +2,8 @@ package com.nekobot.app.ui.screens.chat
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Checklist
-import androidx.compose.material.icons.filled.Flag
-import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -19,7 +12,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.FontWeight
@@ -33,7 +25,7 @@ import com.nekobot.app.R
  * 内置命令的彩色胶囊样式。
  *
  * 目前仅 /goal、/spec 使用胶囊渲染（输入框内替换命令字符、发送后用户气泡同步展示）；
- * 每种命令有独立的图标、渐变底色与多语言标签，方便后续扩展更多命令。
+ * 每种命令有独立的渐变底色与多语言文字标签，方便后续扩展更多命令。
  */
 internal enum class CommandCapsuleKind {
     GOAL,
@@ -44,12 +36,6 @@ internal enum class CommandCapsuleKind {
         get() = when (this) {
             GOAL -> R.string.command_capsule_goal
             SPEC -> R.string.command_capsule_spec
-        }
-
-    val icon: ImageVector
-        get() = when (this) {
-            GOAL -> Icons.Filled.Flag
-            SPEC -> Icons.Filled.Checklist
         }
 
     /** 胶囊渐变起始色（深色系，保证白色文字可读）。 */
@@ -122,7 +108,7 @@ internal fun commandCapsuleVisualTransformation(): VisualTransformation = Visual
 }
 
 /**
- * 命令胶囊组件：圆角胶囊 + 命令图标 + 多语言标签。
+ * 命令胶囊组件：圆角胶囊 + 多语言文字标签（纯文字，不带图标）。
  *
  * [translucent] 为 true 时使用半透明白底（适合放在已着色的气泡/背景上），
  * 否则使用命令自身的渐变底色（适合放在输入框等浅色背景上）。
@@ -131,8 +117,7 @@ internal fun commandCapsuleVisualTransformation(): VisualTransformation = Visual
 internal fun CommandCapsuleChip(
     kind: CommandCapsuleKind,
     modifier: Modifier = Modifier,
-    translucent: Boolean = false,
-    showIcon: Boolean = true
+    translucent: Boolean = false
 ) {
     val label = stringResource(kind.labelResId)
     Row(
@@ -145,18 +130,9 @@ internal fun CommandCapsuleChip(
                     Brush.horizontalGradient(listOf(kind.startColor, kind.endColor))
                 }
             )
-            .padding(horizontal = if (showIcon) 12.dp else 16.dp, vertical = 5.dp),
+            .padding(horizontal = 14.dp, vertical = 5.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
-        if (showIcon) {
-            Icon(
-                imageVector = kind.icon,
-                contentDescription = null,
-                tint = Color.White,
-                modifier = Modifier.size(15.dp)
-            )
-            Spacer(Modifier.width(6.dp))
-        }
         Text(
             text = label,
             style = MaterialTheme.typography.labelMedium,

--- a/app/src/main/kotlin/com/nekobot/app/ui/screens/chat/CommandCapsule.kt
+++ b/app/src/main/kotlin/com/nekobot/app/ui/screens/chat/CommandCapsule.kt
@@ -1,0 +1,168 @@
+package com.nekobot.app.ui.screens.chat
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Checklist
+import androidx.compose.material.icons.filled.Flag
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.OffsetMapping
+import androidx.compose.ui.text.input.TransformedText
+import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.unit.dp
+import com.nekobot.app.R
+
+/**
+ * 内置命令的彩色胶囊样式。
+ *
+ * 目前仅 /goal、/spec 使用胶囊渲染（输入框内替换命令字符、发送后用户气泡同步展示）；
+ * 每种命令有独立的图标、渐变底色与多语言标签，方便后续扩展更多命令。
+ */
+internal enum class CommandCapsuleKind {
+    GOAL,
+    SPEC;
+
+    /** 胶囊上显示的多语言文本资源 id（如“目标 / Goal / 目標 / 목표”）。 */
+    val labelResId: Int
+        get() = when (this) {
+            GOAL -> R.string.command_capsule_goal
+            SPEC -> R.string.command_capsule_spec
+        }
+
+    val icon: ImageVector
+        get() = when (this) {
+            GOAL -> Icons.Filled.Flag
+            SPEC -> Icons.Filled.Checklist
+        }
+
+    /** 胶囊渐变起始色（深色系，保证白色文字可读）。 */
+    val startColor: Color
+        get() = when (this) {
+            GOAL -> Color(0xFF00A86B)
+            SPEC -> Color(0xFF7C4DFF)
+        }
+
+    /** 胶囊渐变结束色。 */
+    val endColor: Color
+        get() = when (this) {
+            GOAL -> Color(0xFF007A4D)
+            SPEC -> Color(0xFF5A2FCB)
+        }
+}
+
+/** 文本开头匹配到的命令胶囊；[token] 保留用户在原文中的实际写法（大小写）。 */
+internal data class CommandCapsuleMatch(
+    val kind: CommandCapsuleKind,
+    val token: String,
+    val tokenRange: IntRange
+)
+
+/**
+ * 匹配输入 / 消息文本开头的 /goal、/spec 命令（与 [com.nekobot.app.data.local.LocalSlashCommands.parse]
+ * 的识别方式一致：命令以空格或换行结尾），未匹配返回 null。
+ */
+internal fun matchCommandCapsule(text: String): CommandCapsuleMatch? {
+    if (!text.startsWith('/')) return null
+    var tokenEnd = text.length
+    for (i in text.indices) {
+        val c = text[i]
+        if (c == ' ' || c == '\n') {
+            tokenEnd = i
+            break
+        }
+    }
+    if (tokenEnd <= 0) return null
+    val token = text.substring(0, tokenEnd)
+    val kind = when (token.lowercase()) {
+        "/goal" -> CommandCapsuleKind.GOAL
+        "/spec" -> CommandCapsuleKind.SPEC
+        else -> null
+    } ?: return null
+    return CommandCapsuleMatch(kind = kind, token = token, tokenRange = 0 until tokenEnd)
+}
+
+/**
+ * 输入框的视觉变换：把开头的 /goal、/spec 命令字符（含其后一个空格）从编辑区隐藏，
+ * 由装饰层（decorationBox / prefix）在同一位置绘制彩色胶囊，从而“命令字符变为胶囊”。
+ *
+ * 光标与选区仍使用原文本坐标；命中区域被折叠为显示区起点偏移 0。
+ */
+internal fun commandCapsuleVisualTransformation(): VisualTransformation = VisualTransformation { text ->
+    val match = matchCommandCapsule(text.text)
+        ?: return@VisualTransformation TransformedText(text, OffsetMapping.Identity)
+    // 连命令后的一个空格一起隐藏，避免胶囊与参数之间出现多余前导空格
+    var hiddenLength = match.token.length
+    if (hiddenLength < text.text.length && text.text[hiddenLength] == ' ') hiddenLength++
+    val display = AnnotatedString(text.text.drop(hiddenLength))
+    val mapping = object : OffsetMapping {
+        override fun originalToTransformed(offset: Int): Int =
+            if (offset <= hiddenLength) 0 else offset - hiddenLength
+
+        override fun transformedToOriginal(offset: Int): Int =
+            if (offset <= 0) 0 else offset + hiddenLength
+    }
+    TransformedText(display, mapping)
+}
+
+/**
+ * 命令胶囊组件：圆角胶囊 + 命令图标 + 多语言标签。
+ *
+ * [translucent] 为 true 时使用半透明白底（适合放在已着色的气泡/背景上），
+ * 否则使用命令自身的渐变底色（适合放在输入框等浅色背景上）。
+ */
+@Composable
+internal fun CommandCapsuleChip(
+    kind: CommandCapsuleKind,
+    modifier: Modifier = Modifier,
+    translucent: Boolean = false,
+    showIcon: Boolean = true
+) {
+    val label = stringResource(kind.labelResId)
+    Row(
+        modifier = modifier
+            .clip(RoundedCornerShape(50))
+            .background(
+                if (translucent) {
+                    Color.White.copy(alpha = 0.28f)
+                } else {
+                    Brush.horizontalGradient(listOf(kind.startColor, kind.endColor))
+                }
+            )
+            .padding(horizontal = if (showIcon) 12.dp else 16.dp, vertical = 5.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        if (showIcon) {
+            Icon(
+                imageVector = kind.icon,
+                contentDescription = null,
+                tint = Color.White,
+                modifier = Modifier.size(15.dp)
+            )
+            Spacer(Modifier.width(6.dp))
+        }
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelMedium,
+            color = Color.White,
+            fontWeight = FontWeight.SemiBold,
+            maxLines = 1
+        )
+    }
+}

--- a/app/src/main/kotlin/com/nekobot/app/ui/screens/chat/ModernChatScreen.kt
+++ b/app/src/main/kotlin/com/nekobot/app/ui/screens/chat/ModernChatScreen.kt
@@ -667,6 +667,10 @@ private fun ModernChatComposer(
         )
     }
     val input = inputField.text
+    // 命令胶囊：/goal、/spec 前缀在输入框内替换为彩色胶囊（视觉变换隐藏命令字符，
+    // 胶囊由 decorationBox 在同样位置绘制；发送内容不受影响，仍是原始文本）
+    val commandCapsule = remember(input) { matchCommandCapsule(input) }
+    val commandCapsuleTransformation = remember { commandCapsuleVisualTransformation() }
     // 程序化更新输入内容时光标置于末尾，方便继续输入
     fun updateInput(text: String) {
         inputField = TextFieldValue(text, TextRange(text.length))
@@ -1266,6 +1270,7 @@ private fun ModernChatComposer(
                                     // Agent 会话生成中仍可输入，发送的消息会进入排队队列
                                     enabled = !sending || isAgentSession,
                                     maxLines = 5,
+                                    visualTransformation = commandCapsuleTransformation,
                                     textStyle = MaterialTheme.typography.bodyLarge.copy(
                                         color = MaterialTheme.colorScheme.onSurface
                                     ),
@@ -1273,23 +1278,33 @@ private fun ModernChatComposer(
                                         .fillMaxWidth()
                                         .padding(horizontal = 12.dp, vertical = 10.dp),
                                     decorationBox = { innerTextField ->
-                                        Box(
+                                        Row(
                                             modifier = Modifier.fillMaxWidth(),
-                                            contentAlignment = Alignment.TopStart
+                                            verticalAlignment = Alignment.CenterVertically
                                         ) {
-                                            if (input.isEmpty()) {
-                                                Text(
-                                                    text = when {
-                                                        sending && isAgentSession ->
-                                                            stringResource(R.string.chat_queue_input_hint)
-                                                        sending -> stringResource(R.string.chat_ai_thinking)
-                                                        else -> stringResource(R.string.chat_input_placeholder)
-                                                    },
-                                                    style = MaterialTheme.typography.bodyLarge,
-                                                    color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.72f)
-                                                )
+                                            // 命令胶囊：视觉变换已隐藏原文中的 /goal、/spec 字符，这里原位绘制胶囊
+                                            if (commandCapsule != null) {
+                                                CommandCapsuleChip(kind = commandCapsule.kind)
+                                                Spacer(Modifier.width(6.dp))
                                             }
-                                            innerTextField()
+                                            Box(
+                                                modifier = Modifier.weight(1f),
+                                                contentAlignment = Alignment.TopStart
+                                            ) {
+                                                if (input.isEmpty()) {
+                                                    Text(
+                                                        text = when {
+                                                            sending && isAgentSession ->
+                                                                stringResource(R.string.chat_queue_input_hint)
+                                                            sending -> stringResource(R.string.chat_ai_thinking)
+                                                            else -> stringResource(R.string.chat_input_placeholder)
+                                                        },
+                                                        style = MaterialTheme.typography.bodyLarge,
+                                                        color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.72f)
+                                                    )
+                                                }
+                                                innerTextField()
+                                            }
                                         }
                                     }
                                 )

--- a/app/src/main/res/values-en/strings_commands.xml
+++ b/app/src/main/res/values-en/strings_commands.xml
@@ -8,6 +8,8 @@
     <string name="command_suggestion_detail_title">Command Details</string>
     <string name="command_suggestion_detail_hint">Long-press an option to see the full description</string>
     <string name="command_suggestion_aliases">Aliases: %1$s</string>
+    <string name="command_capsule_goal">Goal</string>
+    <string name="command_capsule_spec">Spec</string>
     <string name="cmd_help_usage">/help</string>
     <string name="cmd_help_desc">Show local command help</string>
     <string name="cmd_status_usage">/status</string>

--- a/app/src/main/res/values-ja/strings_commands.xml
+++ b/app/src/main/res/values-ja/strings_commands.xml
@@ -8,6 +8,8 @@
     <string name="command_suggestion_detail_title">コマンド詳細</string>
     <string name="command_suggestion_detail_hint">項目を長押しすると完全な説明を表示します</string>
     <string name="command_suggestion_aliases">別名：%1$s</string>
+    <string name="command_capsule_goal">目標</string>
+    <string name="command_capsule_spec">仕様</string>
     <string name="cmd_help_usage">/help</string>
     <string name="cmd_help_desc">ローカルコマンドのヘルプを表示</string>
     <string name="cmd_status_usage">/status</string>

--- a/app/src/main/res/values-ko/strings_commands.xml
+++ b/app/src/main/res/values-ko/strings_commands.xml
@@ -8,6 +8,8 @@
     <string name="command_suggestion_detail_title">명령 상세</string>
     <string name="command_suggestion_detail_hint">옵션을 길게 눌러 전체 설명 보기</string>
     <string name="command_suggestion_aliases">별칭: %1$s</string>
+    <string name="command_capsule_goal">목표</string>
+    <string name="command_capsule_spec">명세</string>
     <string name="cmd_help_usage">/help</string>
     <string name="cmd_help_desc">로컬 명령 도움말 보기</string>
     <string name="cmd_status_usage">/status</string>

--- a/app/src/main/res/values/strings_commands.xml
+++ b/app/src/main/res/values/strings_commands.xml
@@ -8,6 +8,8 @@
     <string name="command_suggestion_detail_title">命令详情</string>
     <string name="command_suggestion_detail_hint">长按选项可查看完整说明</string>
     <string name="command_suggestion_aliases">别名：%1$s</string>
+    <string name="command_capsule_goal">目标</string>
+    <string name="command_capsule_spec">规格</string>
     <string name="cmd_note_usage">/note &lt;内容&gt;</string>
     <string name="cmd_note_desc">追加一条本地工作区速记</string>
     <string name="cmd_notes_usage">/notes</string>

--- a/app/src/test/kotlin/com/nekobot/app/ui/screens/chat/CommandCapsuleTest.kt
+++ b/app/src/test/kotlin/com/nekobot/app/ui/screens/chat/CommandCapsuleTest.kt
@@ -1,0 +1,83 @@
+package com.nekobot.app.ui.screens.chat
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class CommandCapsuleTest {
+
+    @Test
+    fun noMatchForPlainText() {
+        assertNull(matchCommandCapsule(""))
+        assertNull(matchCommandCapsule("你好"))
+        assertNull(matchCommandCapsule("帮我写代码"))
+        assertNull(matchCommandCapsule("  /goal 前面有空格"))
+    }
+
+    @Test
+    fun noMatchForOtherCommandsAndTypos() {
+        assertNull(matchCommandCapsule("/help"))
+        assertNull(matchCommandCapsule("/goalx"))
+        assertNull(matchCommandCapsule("/goa"))
+        assertNull(matchCommandCapsule("/specify"))
+        assertNull(matchCommandCapsule("text /goal 中间出现"))
+    }
+
+    @Test
+    fun matchesGoalWithAndWithoutArgs() {
+        val bare = matchCommandCapsule("/goal")
+        assertEquals(CommandCapsuleKind.GOAL, bare?.kind)
+        assertEquals("/goal", bare?.token)
+
+        val withArgs = matchCommandCapsule("/goal 学会做饭")
+        assertEquals(CommandCapsuleKind.GOAL, withArgs?.kind)
+        assertEquals("/goal", withArgs?.token)
+        assertEquals(0 until 5, withArgs?.tokenRange)
+    }
+
+    @Test
+    fun matchesSpecWithAndWithoutArgs() {
+        val bare = matchCommandCapsule("/spec")
+        assertEquals(CommandCapsuleKind.SPEC, bare?.kind)
+        assertEquals("/spec", bare?.token)
+
+        val withArgs = matchCommandCapsule("/spec 登录模块")
+        assertEquals(CommandCapsuleKind.SPEC, withArgs?.kind)
+        assertEquals("/spec", withArgs?.token)
+    }
+
+    @Test
+    fun matchesCaseInsensitiveAndNewlineTerminated() {
+        val upper = matchCommandCapsule("/GOAL 跑步")
+        assertEquals(CommandCapsuleKind.GOAL, upper?.kind)
+        // token 保留用户原始写法
+        assertEquals("/GOAL", upper?.token)
+
+        val newline = matchCommandCapsule("/spec\n先看文档")
+        assertEquals(CommandCapsuleKind.SPEC, newline?.kind)
+        assertEquals("/spec", newline?.token)
+    }
+
+    @Test
+    fun visualTransformationHidesTokenAndTrailingSpace() {
+        val transformation = commandCapsuleVisualTransformation()
+
+        val plain = transformation.filter(androidx.compose.ui.text.AnnotatedString("帮我做事"))
+        assertEquals("帮我做事", plain.text.text)
+
+        val cmd = transformation.filter(androidx.compose.ui.text.AnnotatedString("/goal 学会做饭"))
+        assertEquals("学会做饭", cmd.text.text)
+        // 命中区域（含空格）折叠为起点 0
+        assertEquals(0, cmd.offsetMapping.originalToTransformed(0))
+        assertEquals(0, cmd.offsetMapping.originalToTransformed(6))
+        assertEquals(0, cmd.offsetMapping.transformedToOriginal(0))
+        assertEquals("/goal 学会做饭".length, cmd.offsetMapping.transformedToOriginal(cmd.text.text.length))
+    }
+
+    @Test
+    fun visualTransformationKeepsPlainTextForNonCommands() {
+        val transformation = commandCapsuleVisualTransformation()
+        val result = transformation.filter(androidx.compose.ui.text.AnnotatedString("/help"))
+        assertEquals("/help", result.text.text)
+    }
+}


### PR DESCRIPTION
## 概述

输入 `/goal`、`/spec` 命令时，输入框内的命令字符替换为**不同颜色的文字胶囊**（绿色「目标」/ 紫色「规格」，纯文字标签，跟随系统语言 zh/en/ja/ko）；发送后，对应的用户气泡底色切换为命令专属渐变，气泡内显示胶囊 + 参数文本。

## 改动内容

| 文件 | 说明 |
|---|---|
| `app/src/main/kotlin/com/nekobot/app/ui/screens/chat/CommandCapsule.kt`（新增） | `CommandCapsuleKind`（GOAL/SPEC 渐变底色 + 多语言标签）、`matchCommandCapsule()` 命令匹配（与 `LocalSlashCommands.parse` 规则一致）、`commandCapsuleVisualTransformation()` 输入框视觉变换、`CommandCapsuleChip()` 纯文字胶囊组件 |
| `ModernChatScreen.kt` | `ModernChatComposer` 输入框接入视觉变换，`decorationBox` 原位绘制胶囊；发送内容仍为原始文本，不影响命令解析 |
| `ChatScreen.kt` | `MessageBubble`：命令消息气泡切换命令色渐变 + 胶囊 + 参数文本（支持 Markdown）；备用输入栏 `ChatInputBar` 同步支持 |
| `res/values(-en/-ja/-ko)/strings_commands.xml` | 新增 `command_capsule_goal` / `command_capsule_spec` 四语言标签 |
| `CommandCapsuleTest.kt`（新增） | 匹配规则、大小写、换行终止、视觉变换偏移映射等 6 个单元测试 |

## 验证情况

- ✅ XML 解析校验、括号配平、diff 逐行审查通过；所用 API 均与项目现有用法交叉确认
- ⚠️ 当前环境无 JDK/Android SDK，**未实际编译与运行单元测试**，需在 CI 或本地构建确认

## 设计说明

- 输入框内命令区（含其后一个空格）在视觉上折叠为胶囊，光标/选区仍使用原文本坐标；在胶囊前编辑会先「去胶囊化」显示原文，便于修改命令
- 气泡胶囊效果仅应用于单段文本命令（正常命令均为单段）