### PR TITLE
feat(chat): 消息气泡 token 数以 k/M 紧凑格式显示

### DIFF
--- a/app/src/main/kotlin/com/nekobot/app/ui/screens/chat/ChatScreen.kt
+++ b/app/src/main/kotlin/com/nekobot/app/ui/screens/chat/ChatScreen.kt
@@ -3097,7 +3097,7 @@ private fun MessageBubble(
                     }
                     message.tokens?.let { tokens ->
                         if (compactTs != null) Spacer(Modifier.width(6.dp))
-                        Text("${tokens} tok", style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                        Text("${formatTokenCount(tokens)} tok", style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
                     }
                 }
                 // 用户气泡：复制按钮放最右边；AI 气泡：三个操作按钮放最右边

--- a/app/src/main/kotlin/com/nekobot/app/ui/screens/chat/ChatValueFormatter.kt
+++ b/app/src/main/kotlin/com/nekobot/app/ui/screens/chat/ChatValueFormatter.kt
@@ -12,3 +12,28 @@ internal fun formatJsonForDisplay(value: Any): String {
             .toJson(value)
     }.getOrElse { value.toString() }
 }
+
+/**
+ * 将 token 数量格式化为易读的紧凑写法：
+ * - 小于 1k：原样数字（如 512、999）
+ * - 千位：一位小数并去掉多余的 0；k 值 ≥ 100 时直接用整数（如 1.2k、9.8k、10k、123k、999k）
+ * - 百万位：一位小数并去掉多余的 0；值 ≥ 100 时直接用整数（如 1.5M、12M、350M）
+ * - k 值 ≥ 999.95（四舍五入后为 1000k）时进位到 M（如 999950 → 1M）
+ */
+internal fun formatTokenCount(tokens: Int): String {
+    if (tokens < 1000) return tokens.toString()
+    var value = tokens / 1000.0
+    var suffix = "k"
+    if (value >= 999.95) {
+        value = tokens / 1_000_000.0
+        suffix = "M"
+    }
+    val text = if (value >= 100) {
+        value.toInt().toString()
+    } else {
+        String.format(java.util.Locale.US, "%.1f", value)
+            .trimEnd('0')
+            .trimEnd('.')
+    }
+    return "$text$suffix"
+}

--- a/app/src/test/kotlin/com/nekobot/app/ui/screens/chat/ChatValueFormatterTest.kt
+++ b/app/src/test/kotlin/com/nekobot/app/ui/screens/chat/ChatValueFormatterTest.kt
@@ -1,5 +1,6 @@
 package com.nekobot.app.ui.screens.chat
 
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -14,5 +15,30 @@ class ChatValueFormatterTest {
 
         assertTrue(formatted.contains("path=/workspace/file.txt"))
         assertFalse(formatted.contains("\\u003d"))
+    }
+
+    @Test
+    fun formatTokenCount_showsPlainNumberBelowOneK() {
+        assertEquals("0", formatTokenCount(0))
+        assertEquals("512", formatTokenCount(512))
+        assertEquals("999", formatTokenCount(999))
+    }
+
+    @Test
+    fun formatTokenCount_usesKForThousands() {
+        assertEquals("1k", formatTokenCount(1_000))
+        assertEquals("1.2k", formatTokenCount(1_234))
+        assertEquals("9.8k", formatTokenCount(9_750))
+        assertEquals("10k", formatTokenCount(10_000))
+        assertEquals("123k", formatTokenCount(123_456))
+        assertEquals("999k", formatTokenCount(999_940))
+        assertEquals("1M", formatTokenCount(999_950))
+    }
+
+    @Test
+    fun formatTokenCount_usesMForMillions() {
+        assertEquals("1.5M", formatTokenCount(1_500_000))
+        assertEquals("12M", formatTokenCount(12_000_000))
+        assertEquals("350M", formatTokenCount(350_000_000))
     }
 }


### PR DESCRIPTION
## 概述

消息气泡下方的 token 数（如 `12345 tok`）改为紧凑格式：**小于 1k 显示原数字**（512、999），千位显示 `k`（1.2k、10k、123k），百万位显示 `M`（1.5M、12M、350M）。

## 显示规则

| 输入 | 显示 |
|---|---|
| 0 / 512 / 999 | `0` / `512` / `999` |
| 1_000 / 1_234 / 9_750 | `1k` / `1.2k` / `9.8k` |
| 10_000 / 123_456 / 999_940 | `10k` / `123k` / `999k` |
| 999_950+ / 1_500_000 | `1M` / `1.5M` |
| 12_000_000 / 350_000_000 | `12M` / `350M` |

## 改动内容

| 文件 | 说明 |
|---|---|
| `ChatValueFormatter.kt` | 新增 `formatTokenCount()`：< 1000 原样；k/M 一位小数（去尾零）；值 ≥ 100 取整数；k 值 ≥ 999.95 进位到 M |
| `ChatScreen.kt` | 气泡下方 `Text("${tokens} tok")` 改用 `formatTokenCount(tokens)` |
| `ChatValueFormatterTest.kt` | 新增 3 组测试：<1k 原数字、k 格式（含进位边界 999950 → 1M）、M 格式 |

## 验证情况

- ✅ 所有边界用例已用等价算法离线核对（含 999950 → 1M 进位、去尾零）
- ⚠️ 当前环境无 JDK/Android SDK，未实际编译运行单元测试，需 CI 或本地构建确认