### PR TITLE
feat(settings): 新增 Agent 设置，支持配置最大工具调用次数

### DIFF
--- a/app/src/main/kotlin/com/nekobot/app/data/local/LocalRepository.kt
+++ b/app/src/main/kotlin/com/nekobot/app/data/local/LocalRepository.kt
@@ -5765,6 +5765,8 @@ class LocalRepository(
                             ctx = ctx,
                             callbacks = callbacks,
                             tools = tools,
+                            // Agent 单轮工具调用次数上限，可在 设置 → Agent 设置 中调整
+                            maxToolIterations = com.nekobot.app.ServiceContainer.prefs.agentMaxToolCalls,
                             // Pipeline 的字符窗口只作最后的防护；Agent 自动压缩的触发
                             // 已使用模型配置的 token 上限，避免过早压缩历史。
                             maxContextChars = maxContextTokens,

--- a/app/src/main/kotlin/com/nekobot/app/data/local/PrefsManager.kt
+++ b/app/src/main/kotlin/com/nekobot/app/data/local/PrefsManager.kt
@@ -230,7 +230,14 @@ class PrefsManager(context: Context) {
             prefs.edit().putString(KEY_SMART_ROUTING_BUDGET_ALERT, value).apply()
         }
 
-    // ==================== RAG 检索配置 ====================
+    // ============ Agent 运行配置 ============
+
+    /** Agent 会话单轮最大工具调用次数（默认 150，范围 1-1000） */
+    var agentMaxToolCalls: Int
+        get() = prefs.getInt(KEY_AGENT_MAX_TOOL_CALLS, 150)
+        set(value) = prefs.edit().putInt(KEY_AGENT_MAX_TOOL_CALLS, value.coerceIn(1, 1000)).apply()
+
+    // ============ RAG 检索配置 ============
 
     /** 语义检索权重（0.0~1.0） */
     var ragSemanticWeight: Float
@@ -710,6 +717,7 @@ class PrefsManager(context: Context) {
         private const val KEY_REASONING_EFFORT_LEGACY = "reasoning_effort"
         private const val KEY_AGENT_REASONING_EFFORT = "reasoning_effort_agent"
         private const val KEY_CHARACTER_REASONING_EFFORT = "reasoning_effort_character"
+        private const val KEY_AGENT_MAX_TOOL_CALLS = "agent_max_tool_calls"
         private const val KEY_SMART_ROUTING_DAILY_BUDGET = "smart_routing_daily_budget"
         private const val KEY_SMART_ROUTING_BUDGET_ALERT = "smart_routing_budget_alert"
         private const val KEY_RAG_SEMANTIC_WEIGHT = "rag_semantic_weight"

--- a/app/src/main/kotlin/com/nekobot/app/ui/navigation/NavGraph.kt
+++ b/app/src/main/kotlin/com/nekobot/app/ui/navigation/NavGraph.kt
@@ -70,6 +70,7 @@ import com.nekobot.app.ui.screens.settings.DbProfileScreen
 import com.nekobot.app.ui.screens.settings.DiagnosticCenterScreen
 import com.nekobot.app.ui.screens.settings.FeatureSwitchesScreen
 import com.nekobot.app.ui.screens.settings.AbTestSettingsScreen
+import com.nekobot.app.ui.screens.settings.AgentSettingsScreen
 import com.nekobot.app.ui.screens.settings.RagSettingsScreen
 import com.nekobot.app.ui.screens.settings.SettingsScreen
 import com.nekobot.app.ui.screens.settings.StyleSettingsScreen
@@ -575,6 +576,9 @@ fun NekobotNavGraph() {
             }
             composable(Routes.FEATURE_SWITCHES) {
                 FeatureSwitchesScreen(onBack = { navController.popBackStack() })
+            }
+            composable(Routes.AGENT_SETTINGS) {
+                AgentSettingsScreen(onBack = { navController.popBackStack() })
             }
             composable(Routes.DATA_MAINTENANCE) {
                 DataMaintenanceScreen(onBack = { navController.popBackStack() })

--- a/app/src/main/kotlin/com/nekobot/app/ui/navigation/Routes.kt
+++ b/app/src/main/kotlin/com/nekobot/app/ui/navigation/Routes.kt
@@ -66,6 +66,8 @@ object Routes {
     const val DATA_PORTABILITY = "data_portability"
     const val FEATURE_SWITCHES = "feature_switches"
     const val DATA_MAINTENANCE = "data_maintenance"
+    /** Agent 设置 */
+    const val AGENT_SETTINGS = "agent_settings"
     /** 路由决策历史 */
     const val ROUTING_HISTORY = "routing_history"
     /** A/B 测试配置 */

--- a/app/src/main/kotlin/com/nekobot/app/ui/screens/settings/AgentSettingsScreen.kt
+++ b/app/src/main/kotlin/com/nekobot/app/ui/screens/settings/AgentSettingsScreen.kt
@@ -1,0 +1,169 @@
+package com.nekobot.app.ui.screens.settings
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Psychology
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextFieldDefaults
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardOptions
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import com.nekobot.app.R
+import com.nekobot.app.ServiceContainer
+import com.nekobot.app.ui.components.BorderlessOutlinedTextField as OutlinedTextField
+import com.nekobot.app.ui.components.GlassCard
+
+/** Agent 设置下所有数值的可选范围与默认值，保持与 PrefsManager 一致。 */
+private const val MAX_TOOL_CALLS_MIN = 1
+private const val MAX_TOOL_CALLS_MAX = 1000
+private const val MAX_TOOL_CALLS_DEFAULT = 150
+
+/**
+ * Agent 设置界面：布局沿用「拓展功能」风格（分组卡片 + 彩色图标行），
+ * 目前包含 Agent 会话运行限制设置。
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AgentSettingsScreen(onBack: () -> Unit) {
+    Scaffold(
+        containerColor = MaterialTheme.colorScheme.background,
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(R.string.agent_settings_title), color = MaterialTheme.colorScheme.onSurface, fontWeight = FontWeight.SemiBold) },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.surface,
+                    titleContentColor = MaterialTheme.colorScheme.onSurface
+                ),
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = stringResource(R.string.common_back), tint = MaterialTheme.colorScheme.onSurface)
+                    }
+                }
+            )
+        }
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .verticalScroll(rememberScrollState())
+                .padding(start = 16.dp, end = 16.dp, top = 16.dp, bottom = 24.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            // 运行限制分组：组标题 + 设置行（沿用拓展功能分组的卡片样式）
+            GlassCard(modifier = Modifier.fillMaxWidth()) {
+                Text(
+                    text = stringResource(R.string.agent_settings_group_runtime),
+                    style = MaterialTheme.typography.labelLarge,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    fontWeight = FontWeight.SemiBold,
+                    modifier = Modifier.padding(bottom = 6.dp, start = 2.dp)
+                )
+                AgentSettingRow(
+                    icon = Icons.Filled.Psychology,
+                    tint = MaterialTheme.colorScheme.primary,
+                    title = stringResource(R.string.agent_settings_max_tool_calls),
+                    desc = stringResource(R.string.agent_settings_max_tool_calls_desc, MAX_TOOL_CALLS_DEFAULT),
+                    trailing = {
+                        ToolCallsInput()
+                    }
+                )
+            }
+        }
+    }
+}
+
+/** 最大工具调用次数：数字输入，仅允许数字，合法范围（1-1000）内即时保存。 */
+@Composable
+private fun ToolCallsInput() {
+    var text by remember {
+        mutableStateOf(ServiceContainer.prefs.agentMaxToolCalls.toString())
+    }
+    OutlinedTextField(
+        value = text,
+        onValueChange = { input ->
+            val filtered = input.filter { it.isDigit() }
+            text = filtered
+            filtered.toIntOrNull()?.let { num ->
+                if (num in MAX_TOOL_CALLS_MIN..MAX_TOOL_CALLS_MAX) {
+                    ServiceContainer.prefs.agentMaxToolCalls = num
+                }
+            }
+        },
+        singleLine = true,
+        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+        textStyle = MaterialTheme.typography.bodyMedium,
+        shape = RoundedCornerShape(12.dp),
+        colors = OutlinedTextFieldDefaults.colors(
+            focusedIndicatorColor = MaterialTheme.colorScheme.primary,
+            unfocusedIndicatorColor = MaterialTheme.colorScheme.outline
+        ),
+        modifier = Modifier.width(92.dp)
+    )
+}
+
+/** Agent 设置行：彩色图标底座 + 标题/描述 + 右侧控件（沿用拓展功能单行布局）。 */
+@Composable
+private fun AgentSettingRow(
+    icon: androidx.compose.ui.graphics.vector.ImageVector,
+    tint: Color,
+    title: String,
+    desc: String,
+    trailing: @Composable () -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Box(
+            modifier = Modifier
+                .size(40.dp)
+                .clip(RoundedCornerShape(10.dp))
+                .background(tint.copy(alpha = 0.16f)),
+            contentAlignment = Alignment.Center
+        ) {
+            Icon(icon, contentDescription = null, tint = tint, modifier = Modifier.size(22.dp))
+        }
+        Spacer(Modifier.width(12.dp))
+        Column(modifier = Modifier.weight(1f)) {
+            Text(title, style = MaterialTheme.typography.bodyLarge, color = MaterialTheme.colorScheme.onSurface, fontWeight = FontWeight.SemiBold)
+            Text(desc, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant, maxLines = 2)
+        }
+        Spacer(Modifier.width(12.dp))
+        trailing()
+    }
+}

--- a/app/src/main/kotlin/com/nekobot/app/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/nekobot/app/ui/screens/settings/SettingsScreen.kt
@@ -49,6 +49,7 @@ import androidx.compose.material.icons.filled.Tune
 import androidx.compose.material.icons.filled.Logout
 import androidx.compose.material.icons.filled.Memory
 import androidx.compose.material.icons.filled.Person
+import androidx.compose.material.icons.filled.Psychology
 import androidx.compose.material.icons.filled.Save
 import androidx.compose.material.icons.filled.SystemUpdate
 import androidx.compose.material.icons.filled.Settings as SettingsIcon
@@ -741,6 +742,18 @@ fun SettingsScreen(onLogout: () -> Unit, onNavigate: (String) -> Unit, onBack: (
                             subtitle = stringResource(R.string.settings_webdav_backup_desc)
                         ) { onNavigate("webdav_backup") }
                     }
+                }
+
+                // 4.6 Agent 设置（Agent 会话运行参数）
+                GlassCard(modifier = Modifier.fillMaxWidth()) {
+                    SectionHeader(title = stringResource(R.string.settings_agent_settings))
+                    Spacer(Modifier.height(8.dp))
+                    SettingNavRow(
+                        icon = Icons.Filled.Psychology,
+                        iconColor = MaterialTheme.colorScheme.primary,
+                        title = stringResource(R.string.agent_settings_title),
+                        subtitle = stringResource(R.string.settings_agent_settings_desc)
+                    ) { onNavigate("agent_settings") }
                 }
 
                 // 5. 日志查看（服务器模式看服务端日志，本地模式看 LocalLogger）

--- a/app/src/main/res/values-en/strings_settings_sub.xml
+++ b/app/src/main/res/values-en/strings_settings_sub.xml
@@ -260,4 +260,10 @@
     <string name="webdav_auto_incremental_interval_hours_desc">Set 1–168 hours. Battery optimization may delay execution.</string>
     <string name="webdav_incremental_max_versions">Maximum versions to retain</string>
     <string name="webdav_incremental_max_versions_desc">Set 1–50 versions including the current one; older history is removed automatically.</string>
+    <string name="settings_agent_settings">Agent Settings</string>
+    <string name="settings_agent_settings_desc">Agent session runtime parameters and tool limits</string>
+    <string name="agent_settings_title">Agent Settings</string>
+    <string name="agent_settings_group_runtime">Runtime Limits</string>
+    <string name="agent_settings_max_tool_calls">Max Tool Calls</string>
+    <string name="agent_settings_max_tool_calls_desc">Maximum tool calls allowed in a single Agent turn (1–1000, default %1$d)</string>
 </resources>

--- a/app/src/main/res/values-ja/strings_settings_sub.xml
+++ b/app/src/main/res/values-ja/strings_settings_sub.xml
@@ -253,4 +253,10 @@
     <string name="webdav_auto_incremental_interval_hours_desc">1～168 時間で設定できます。省電力設定により実行が遅れる場合があります。</string>
     <string name="webdav_incremental_max_versions">保持するバージョン数</string>
     <string name="webdav_incremental_max_versions_desc">現在のバージョンを含めて 1～50 件を保持します。超過した履歴は自動削除されます。</string>
+    <string name="settings_agent_settings">Agent 設定</string>
+    <string name="settings_agent_settings_desc">Agent セッションの実行パラメータとツール制限</string>
+    <string name="agent_settings_title">Agent 設定</string>
+    <string name="agent_settings_group_runtime">実行制限</string>
+    <string name="agent_settings_max_tool_calls">最大ツール呼び出し回数</string>
+    <string name="agent_settings_max_tool_calls_desc">1 つの Agent ターンで許可される最大ツール呼び出し回数（1～1000、既定 %1$d）</string>
 </resources>

--- a/app/src/main/res/values-ko/strings_settings_sub.xml
+++ b/app/src/main/res/values-ko/strings_settings_sub.xml
@@ -253,4 +253,10 @@
     <string name="webdav_auto_incremental_interval_hours_desc">1~168시간으로 설정할 수 있습니다. 배터리 최적화로 실행이 지연될 수 있습니다.</string>
     <string name="webdav_incremental_max_versions">보관할 최대 버전 수</string>
     <string name="webdav_incremental_max_versions_desc">현재 버전을 포함해 1~50개를 보관하며, 초과한 기록은 자동으로 삭제합니다.</string>
+    <string name="settings_agent_settings">Agent 설정</string>
+    <string name="settings_agent_settings_desc">Agent 세션 실행 매개변수 및 도구 제한</string>
+    <string name="agent_settings_title">Agent 설정</string>
+    <string name="agent_settings_group_runtime">실행 제한</string>
+    <string name="agent_settings_max_tool_calls">최대 도구 호출 횟수</string>
+    <string name="agent_settings_max_tool_calls_desc">단일 Agent 턴에서 허용되는 최대 도구 호출 횟수(1–1000, 기본 %1$d)</string>
 </resources>

--- a/app/src/main/res/values/strings_settings_sub.xml
+++ b/app/src/main/res/values/strings_settings_sub.xml
@@ -266,4 +266,10 @@
     <string name="webdav_auto_incremental_interval_hours_desc">可设置 1–168 小时；系统可能因省电策略延后执行</string>
     <string name="webdav_incremental_max_versions">最多保留版本数</string>
     <string name="webdav_incremental_max_versions_desc">可设置 1–50 个版本，包含当前版本；超出的历史版本会自动清理</string>
+    <string name="settings_agent_settings">Agent 设置</string>
+    <string name="settings_agent_settings_desc">Agent 会话运行参数与工具限制</string>
+    <string name="agent_settings_title">Agent 设置</string>
+    <string name="agent_settings_group_runtime">运行限制</string>
+    <string name="agent_settings_max_tool_calls">最大工具调用次数</string>
+    <string name="agent_settings_max_tool_calls_desc">单个 Agent 回合内允许的最大工具调用次数（1–1000，默认 %1$d）</string>
 </resources>


### PR DESCRIPTION
## 概述

设置界面新增「**Agent 设置**」入口，独立设置界面布局沿用**拓展功能界面**的分组卡片风格（顶部栏 + 玻璃卡片分组 + 彩色图标行）。首个设置项为「**最大工具调用次数**」（默认 **150**，范围 1–1000），即时生效。

## 界面结构

```
设置 → Agent 设置
└─ 运行限制（GlassCard 分组）
   └─ 🧠 最大工具调用次数  [数字输入框 1-1000]
```

- 设置入口：设置页新增独立卡片「Agent 设置」（全模式显示）
- 设置界面：TopAppBar + 分组卡片 + 图标行，与 `ExtensionsScreen` 的 `ExtensionGroupCard` / `ExtensionRow` 布局一致
- 数字输入：仅允许数字，合法范围（1–1000）内即时保存；描述文案带默认值占位符

## 改动内容

| 文件 | 说明 |
|---|---|
| `AgentSettingsScreen.kt`（新增） | Agent 设置界面；`ToolCallsInput` 数字输入即时保存 |
| `SettingsScreen.kt` | 新增「Agent 设置」入口卡片（`SettingNavRow` → `agent_settings`） |
| `PrefsManager.kt` | 新增 `agentMaxToolCalls` 偏好（默认 150，`coerceIn(1, 1000)`） |
| `LocalRepository.kt` | Agent 会话主路径 `aiPipeline.process()` 接入 `maxToolIterations = prefs.agentMaxToolCalls`（群聊等非 Agent 路径不受影响） |
| `Routes.kt` / `NavGraph.kt` | 注册 `agent_settings` 路由 |
| 4 语言 `strings_settings_sub.xml` | 新增 6 条文案（zh/en/ja/ko） |

## 验证情况

- ✅ 4 个 XML 解析校验通过；括号配平检查通过；调用链确认仅 Agent 主路径接入（另一处 process 为群聊、tools 为空）
- ⚠️ 当前环境无 JDK/Android SDK，未实际编译，需 CI 或本地构建确认