### PR TITLE
feat(chat): Agent 运行期间动态更新 + 菜单上下文占比与分析

### DIFF
--- a/app/src/main/kotlin/com/nekobot/app/data/local/LocalRepository.kt
+++ b/app/src/main/kotlin/com/nekobot/app/data/local/LocalRepository.kt
@@ -7961,6 +7961,48 @@ ${AiOutputLanguage.directive()}
         currentLocalContextTokens(contextMessages)
     }
 
+    /**
+     * Agent 会话运行期间的实时上下文用量。
+     *
+     * Agent 处于思考/工具调用循环中时，本轮新增的助手与工具消息尚未落库，
+     * 但它们会在下一轮模型请求中随 tool_call_history 注入，属于真实上下文。
+     * 这里叠加 agent_run 检查点中已完成的历史估算，使 + 面板的上下文占比与
+     * 分析能随工具调用步骤动态增长；未运行时仅返回持久化窗口用量。
+     */
+    suspend fun agentLiveContextUsage(sessionId: String): AgentLiveContextUsage = withContext(Dispatchers.IO) {
+        val baseTokens = sessionContextTokenUsage(sessionId)
+        val run = agentRunDao.getBySession(sessionId)
+        val checkpoint = run?.checkpointHistory
+        if (run == null || run.status != AgentRunStatus.RUNNING || checkpoint.isNullOrBlank()) {
+            return@withContext AgentLiveContextUsage(
+                baseTokens = baseTokens,
+                liveToolTokens = 0L,
+                liveToolCount = 0,
+                stage = run?.stage,
+                lastToolName = run?.lastToolName,
+                completedToolCalls = run?.completedToolCalls ?: 0,
+                hasActiveRun = false
+            )
+        }
+        // checkpoint_history 是 role=assistant/tool 消息的 JSON 数组；条数用于分析区计数。
+        val liveToolCount = runCatching {
+            JsonParser.parseString(checkpoint)
+                .takeIf { it.isJsonArray }
+                ?.asJsonArray
+                ?.size()
+                ?: 0
+        }.getOrDefault(0)
+        AgentLiveContextUsage(
+            baseTokens = baseTokens,
+            liveToolTokens = estimateLocalTextTokens(checkpoint).toLong(),
+            liveToolCount = liveToolCount,
+            stage = run.stage,
+            lastToolName = run.lastToolName,
+            completedToolCalls = run.completedToolCalls,
+            hasActiveRun = true
+        )
+    }
+
     /** 本地 token 用量排行榜（按 model / session 聚合，从独立存储读取）。 */
     suspend fun tokenRankings(): TokenRankings = withContext(Dispatchers.IO) {
         val records = readTokenUsageRecordsReconciled()
@@ -10472,6 +10514,27 @@ data class ContextCompressionResult(
     val archiveSessionId: String? = null,
     val errorMessage: String? = null
 )
+
+/**
+ * Agent 会话上下文用量的实时快照。
+ *
+ * [baseTokens] 为已落库的上下文窗口估算（与聊天页上下文圆环同口径）；
+ * [liveToolTokens] / [liveToolCount] 为当前一轮运行中尚未落库、但会随
+ * tool_call_history 注入下一轮请求的工具调用历史（agent_run 检查点）估算。
+ * 未运行或非 Agent 会话时 [hasActiveRun] 为 false，live 部分为 0。
+ */
+data class AgentLiveContextUsage(
+    val baseTokens: Long,
+    val liveToolTokens: Long,
+    val liveToolCount: Int,
+    val stage: String?,
+    val lastToolName: String?,
+    val completedToolCalls: Int,
+    val hasActiveRun: Boolean
+) {
+    /** 计入运行中工具调用后的总用量。 */
+    val totalTokens: Long get() = baseTokens + liveToolTokens
+}
 
 /**
  * Room DAO 适配器：将 [com.nekobot.app.data.local.db.FailoverHealthDao] 暴露为

--- a/app/src/main/kotlin/com/nekobot/app/data/repository/UnifiedRepository.kt
+++ b/app/src/main/kotlin/com/nekobot/app/data/repository/UnifiedRepository.kt
@@ -7,6 +7,7 @@ import com.google.gson.JsonObject
 import com.google.gson.JsonParser
 import com.nekobot.app.ServiceContainer
 import com.nekobot.app.data.local.LocalRepository
+import com.nekobot.app.data.local.AgentLiveContextUsage
 import com.nekobot.app.data.local.ai.LocalInteractiveSession
 import com.nekobot.app.data.local.ai.LocalSandboxCommandResult
 import com.nekobot.app.data.local.ai.RealtimeAgentToolRuntime
@@ -960,6 +961,25 @@ class UnifiedRepository(
     /** 当前仍会发送给模型的上下文 Token；本地模式避免重复累计每轮完整 prompt。 */
     suspend fun sessionContextTokenUsage(sessionId: String): Long =
         if (isLocal) local.sessionContextTokenUsage(sessionId) else sessionTokenUsage(sessionId)
+
+    /**
+     * Agent 会话的运行中上下文实时快照：持久化窗口 + 当前一轮尚未落库的工具调用历史。
+     * 本地模式叠加 agent_run 检查点估算；远程模式没有本地运行中的工具历史，仅返回窗口用量。
+     */
+    suspend fun agentLiveContextUsage(sessionId: String): AgentLiveContextUsage =
+        if (isLocal) {
+            local.agentLiveContextUsage(sessionId)
+        } else {
+            AgentLiveContextUsage(
+                baseTokens = sessionContextTokenUsage(sessionId),
+                liveToolTokens = 0L,
+                liveToolCount = 0,
+                stage = null,
+                lastToolName = null,
+                completedToolCalls = 0,
+                hasActiveRun = false
+            )
+        }
 
     // ==================== 角色卡导入 ====================
 

--- a/app/src/main/kotlin/com/nekobot/app/ui/screens/chat/ContextAnalysisModels.kt
+++ b/app/src/main/kotlin/com/nekobot/app/ui/screens/chat/ContextAnalysisModels.kt
@@ -1,5 +1,10 @@
 package com.nekobot.app.ui.screens.chat
 
+import androidx.compose.material3.ColorScheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import com.nekobot.app.R
 import com.nekobot.app.data.local.agentContextSummaryBoundaryId
 import com.nekobot.app.data.local.isAgentContextSummary
 import com.nekobot.app.data.local.ai.estimateLocalTextTokens
@@ -94,6 +99,49 @@ internal fun buildContextBreakdown(
             if (tokens == 0 && count == 0) null else ContextPart(type, tokens, count)
         }
     )
+}
+
+/**
+ * 合并 Agent 运行中（尚未落库、但会随 tool_call_history 注入下一轮请求）的工具调用历史，
+ * 归入 [ContextPartType.TOOL_CALLS]，使占比与分析随工具调用步骤动态增长。
+ */
+internal fun ContextBreakdown.withLiveToolTokens(liveTokens: Long, liveCount: Int): ContextBreakdown {
+    if (liveTokens <= 0 && liveCount <= 0) return this
+    val mapped = parts.map { part ->
+        if (part.type == ContextPartType.TOOL_CALLS) {
+            part.copy(
+                estimatedTokens = part.estimatedTokens + liveTokens.toInt(),
+                itemCount = part.itemCount + liveCount
+            )
+        } else {
+            part
+        }
+    }
+    return if (mapped.none { it.type == ContextPartType.TOOL_CALLS }) {
+        ContextBreakdown(parts = mapped + ContextPart(ContextPartType.TOOL_CALLS, liveTokens.toInt(), liveCount))
+    } else {
+        ContextBreakdown(parts = mapped)
+    }
+}
+
+/** 上下文类型在占比分析中的展示颜色（全屏页与 + 菜单共用）。 */
+internal fun ContextPartType.displayColor(scheme: ColorScheme): Color = when (this) {
+    ContextPartType.SYSTEM_PROMPT -> scheme.primary
+    ContextPartType.USER_MESSAGES -> scheme.secondary
+    ContextPartType.ASSISTANT_MESSAGES -> scheme.tertiary
+    ContextPartType.COMPRESSED_SUMMARY -> scheme.outline
+    ContextPartType.TOOL_CALLS -> scheme.error
+    ContextPartType.OTHER_MESSAGES -> scheme.outline
+}
+
+@Composable
+internal fun contextPartLabel(type: ContextPartType): String = when (type) {
+    ContextPartType.SYSTEM_PROMPT -> stringResource(R.string.chat_context_analysis_system_prompt)
+    ContextPartType.USER_MESSAGES -> stringResource(R.string.chat_context_analysis_user_messages)
+    ContextPartType.ASSISTANT_MESSAGES -> stringResource(R.string.chat_context_analysis_assistant_messages)
+    ContextPartType.COMPRESSED_SUMMARY -> stringResource(R.string.chat_context_analysis_summary)
+    ContextPartType.TOOL_CALLS -> stringResource(R.string.chat_context_analysis_tool_content)
+    ContextPartType.OTHER_MESSAGES -> stringResource(R.string.chat_context_analysis_other_messages)
 }
 
 private fun List<Message>.agentContextWindow(): List<Message> {

--- a/app/src/main/kotlin/com/nekobot/app/ui/screens/chat/ContextAnalysisScreen.kt
+++ b/app/src/main/kotlin/com/nekobot/app/ui/screens/chat/ContextAnalysisScreen.kt
@@ -93,10 +93,22 @@ fun ContextAnalysisScreen(
                     is Resource.Success -> messagesResult.data
                     else -> emptyList()
                 }
+                // Agent 运行中（工具循环未结束）时，尚未落库的工具调用历史也要计入，
+                // 与 + 面板的实时占比口径保持一致。
+                val isAgentSession = session?.sessionMode.equals("agent", ignoreCase = true)
+                val live = if (isAgentSession) {
+                    ServiceContainer.unified.agentLiveContextUsage(sessionId)
+                } else {
+                    null
+                }
                 Result.success(
                     ContextAnalysisData(
-                        breakdown = buildContextBreakdown(session, messages),
-                        usedTokens = ServiceContainer.unified.sessionContextTokenUsage(sessionId),
+                        breakdown = buildContextBreakdown(session, messages)
+                            .let {
+                                if (live == null) it else it.withLiveToolTokens(live.liveToolTokens, live.liveToolCount)
+                            },
+                        usedTokens = live?.totalTokens
+                            ?: ServiceContainer.unified.sessionContextTokenUsage(sessionId),
                         maxTokens = ServiceContainer.unified.getActiveContextLength()
                     )
                 )
@@ -266,14 +278,7 @@ private fun ContextCapacityCard(usedTokens: Long, maxTokens: Int?) {
 
 @Composable
 private fun ContextTypeRow(part: ContextPart, totalTokens: Int) {
-    val color = when (part.type) {
-        ContextPartType.SYSTEM_PROMPT -> MaterialTheme.colorScheme.primary
-        ContextPartType.USER_MESSAGES -> MaterialTheme.colorScheme.secondary
-        ContextPartType.ASSISTANT_MESSAGES -> MaterialTheme.colorScheme.tertiary
-        ContextPartType.COMPRESSED_SUMMARY -> MaterialTheme.colorScheme.outline
-        ContextPartType.TOOL_CALLS -> MaterialTheme.colorScheme.error
-        ContextPartType.OTHER_MESSAGES -> MaterialTheme.colorScheme.outline
-    }
+    val color = part.type.displayColor(MaterialTheme.colorScheme)
     val share = if (totalTokens > 0) part.estimatedTokens.toFloat() / totalTokens else 0f
     val percent = (share * 100).toInt()
     Column(verticalArrangement = Arrangement.spacedBy(7.dp)) {
@@ -318,14 +323,4 @@ private fun ContextTypeRow(part: ContextPart, totalTokens: Int) {
             trackColor = MaterialTheme.colorScheme.surfaceVariant
         )
     }
-}
-
-@Composable
-private fun contextPartLabel(type: ContextPartType): String = when (type) {
-    ContextPartType.SYSTEM_PROMPT -> stringResource(R.string.chat_context_analysis_system_prompt)
-    ContextPartType.USER_MESSAGES -> stringResource(R.string.chat_context_analysis_user_messages)
-    ContextPartType.ASSISTANT_MESSAGES -> stringResource(R.string.chat_context_analysis_assistant_messages)
-    ContextPartType.COMPRESSED_SUMMARY -> stringResource(R.string.chat_context_analysis_summary)
-    ContextPartType.TOOL_CALLS -> stringResource(R.string.chat_context_analysis_tool_content)
-    ContextPartType.OTHER_MESSAGES -> stringResource(R.string.chat_context_analysis_other_messages)
 }

--- a/app/src/main/kotlin/com/nekobot/app/ui/screens/chat/ModernChatScreen.kt
+++ b/app/src/main/kotlin/com/nekobot/app/ui/screens/chat/ModernChatScreen.kt
@@ -86,6 +86,7 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import com.nekobot.app.ui.components.BorderlessOutlinedTextField as OutlinedTextField
 import androidx.compose.material3.Surface
@@ -99,6 +100,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -125,6 +127,8 @@ import coil.compose.AsyncImage
 import com.google.gson.JsonObject
 import com.nekobot.app.R
 import com.nekobot.app.ServiceContainer
+import com.nekobot.app.data.local.AgentLiveContextUsage
+import com.nekobot.app.data.local.ai.AgentRunStage
 import com.nekobot.app.data.local.ChatInputLayoutMode
 import com.nekobot.app.data.local.LocalCommandAction
 import com.nekobot.app.data.local.LocalCommandSuggestion
@@ -976,15 +980,42 @@ private fun ModernChatComposer(
     var maxTokens by remember { mutableStateOf<Int?>(null) }
     // 当前上下文 Token：本地模式取最近一次完整 prompt usage，避免把每轮累计计费用量重复相加
     var usedTokens by remember { mutableStateOf(0L) }
+    // Agent 运行中的实时上下文快照（stage / 工具名 / 已完成工具数 / 运行中工具调用估算）
+    var agentLiveContext by remember { mutableStateOf<AgentLiveContextUsage?>(null) }
+    // + 面板内的上下文构成分析（类型占比）；Agent 运行期间随轮询动态更新
+    var contextBreakdown by remember { mutableStateOf<ContextBreakdown?>(null) }
+    // 轮询时始终读取最新消息/会话，避免 LaunchedEffect 闭包捕获过期列表
+    val latestMessages by rememberUpdatedState(messages)
+    val latestSession by rememberUpdatedState(session)
+    // Agent 运行中的上下文刷新间隔。思考/工具调用期间新消息不落库，
+    // 页面事件不足以触发重算，需要周期性从 agent_run 检查点读取实时估算。
+    val liveContextRefreshIntervalMs = 2000L
     // 消息条数、压缩边界或发送状态变化时刷新（远程模式发送后服务端会先写 token 记录）。
+    // Agent 会话生成期间额外按 [liveContextRefreshIntervalMs] 持续重算，使 + 面板的
+    // 上下文占比与分析随思考/工具调用步骤动态更新；普通生成保持单次刷新。
     LaunchedEffect(sessionId, messageCount, contextRevision, sending) {
         // 进度条分母：当前激活聊天模型的上下文窗口长度（max_context_length）
         // 本地模式和远程模式均通过 unified.getActiveContextLength() 统一获取
         maxTokens = withContext(Dispatchers.IO) {
             ServiceContainer.unified.getActiveContextLength()
         }
-        usedTokens = withContext(Dispatchers.IO) {
-            ServiceContainer.unified.sessionContextTokenUsage(sessionId)
+        while (true) {
+            val live = sending && isAgentSession
+            withContext(Dispatchers.IO) {
+                if (live) {
+                    val liveUsage = ServiceContainer.unified.agentLiveContextUsage(sessionId)
+                    usedTokens = liveUsage.totalTokens
+                    agentLiveContext = liveUsage
+                    contextBreakdown = buildContextBreakdown(latestSession, latestMessages)
+                        .withLiveToolTokens(liveUsage.liveToolTokens, liveUsage.liveToolCount)
+                } else {
+                    usedTokens = ServiceContainer.unified.sessionContextTokenUsage(sessionId)
+                    agentLiveContext = null
+                    contextBreakdown = buildContextBreakdown(latestSession, latestMessages)
+                }
+            }
+            if (!live) break
+            delay(liveContextRefreshIntervalMs)
         }
     }
     val hasPlotSurface = plotChoicesLoading || plotChoices.isNotEmpty()
@@ -1094,6 +1125,8 @@ private fun ModernChatComposer(
                     tokenEstimate = tokenEstimate,
                     usedTokens = usedTokens,
                     maxTokens = maxTokens,
+                    agentLiveContext = agentLiveContext,
+                    contextBreakdown = contextBreakdown,
                     sending = sending,
                     fileBusy = fileBusy,
                     plotMode = plotMode,
@@ -2010,6 +2043,8 @@ private fun ModernChatActionPanel(
     usedTokens: Long,
     maxTokens: Int?,
     sending: Boolean,
+    agentLiveContext: AgentLiveContextUsage?,
+    contextBreakdown: ContextBreakdown?,
     fileBusy: Boolean,
     plotMode: Boolean,
     plotRealTimeSync: Boolean,
@@ -2053,6 +2088,8 @@ private fun ModernChatActionPanel(
                     usedTokens = usedTokens,
                     maxTokens = maxTokens,
                     sending = sending,
+                    agentLiveContext = agentLiveContext,
+                    contextBreakdown = contextBreakdown,
                     onCompress = onCompress,
                     onOpenAnalysis = onOpenContextAnalysis
                 )
@@ -2200,6 +2237,8 @@ private fun ModernContextCard(
     usedTokens: Long,
     maxTokens: Int?,
     sending: Boolean,
+    agentLiveContext: AgentLiveContextUsage?,
+    contextBreakdown: ContextBreakdown?,
     onCompress: () -> Unit,
     onOpenAnalysis: () -> Unit
 ) {
@@ -2208,6 +2247,7 @@ private fun ModernContextCard(
         (usedTokens.toFloat() / maxTokens.toFloat()).coerceIn(0f, 1f)
     } else 0f
     val percent = (progress * 100).toInt()
+    val liveRunning = agentLiveContext?.hasActiveRun == true && sending
 
     Surface(
         modifier = Modifier.fillMaxWidth(),
@@ -2252,7 +2292,11 @@ private fun ModernContextCard(
                             fontWeight = FontWeight.SemiBold
                         )
                         Text(
-                            stringResource(R.string.chat_context_analysis_desc),
+                            if (liveRunning) {
+                                stringResource(R.string.chat_agent_context_live_desc)
+                            } else {
+                                stringResource(R.string.chat_context_analysis_desc)
+                            },
                             style = MaterialTheme.typography.bodySmall,
                             color = MaterialTheme.colorScheme.onSurfaceVariant
                         )
@@ -2274,11 +2318,132 @@ private fun ModernContextCard(
                 ModernMetric(stringResource(R.string.chat_used_tokens), usedTokens.toString(), Modifier.weight(1f))
                 ModernMetric(
                     label = stringResource(R.string.chat_status),
-                    value = if (sending) stringResource(R.string.chat_status_generating) else stringResource(R.string.chat_status_ready),
+                    value = agentStatusText(agentLiveContext, sending),
                     modifier = Modifier.weight(1f)
                 )
             }
+            if (contextBreakdown?.parts?.isNotEmpty() == true) {
+                Spacer(Modifier.height(12.dp))
+                ModernContextAnalysisSection(
+                    breakdown = contextBreakdown,
+                    liveRunning = liveRunning
+                )
+            }
         }
+    }
+}
+
+/** Agent 运行中时展示实时阶段（准备/思考/调用工具），与发送状态联动。 */
+@Composable
+private fun agentStatusText(agentLiveContext: AgentLiveContextUsage?, sending: Boolean): String {
+    if (!sending) return stringResource(R.string.chat_status_ready)
+    val live = agentLiveContext
+    if (live == null) return stringResource(R.string.chat_status_generating)
+    return when (live.stage) {
+        AgentRunStage.PREPARING -> stringResource(R.string.chat_agent_status_preparing)
+        AgentRunStage.THINKING -> stringResource(R.string.chat_agent_status_thinking)
+        AgentRunStage.TOOL ->
+            if (live.lastToolName.isNullOrBlank()) {
+                stringResource(R.string.chat_status_generating)
+            } else {
+                stringResource(R.string.chat_agent_status_tool_running, live.lastToolName)
+            }
+        else -> stringResource(R.string.chat_status_generating)
+    }
+}
+
+/**
+ * + 菜单内的上下文构成分析：类型占比精简列表。
+ * Agent 运行期间随轮询动态刷新，工具调用占比包含尚未落库的进行中历史。
+ */
+@Composable
+private fun ModernContextAnalysisSection(breakdown: ContextBreakdown, liveRunning: Boolean) {
+    Column {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Text(
+                stringResource(R.string.chat_context_analysis_type_breakdown),
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.SemiBold
+            )
+            if (liveRunning) {
+                Spacer(Modifier.width(7.dp))
+                Text(
+                    stringResource(R.string.chat_context_live_badge),
+                    style = MaterialTheme.typography.labelSmall,
+                    fontWeight = FontWeight.SemiBold,
+                    color = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier
+                        .clip(RoundedCornerShape(6.dp))
+                        .background(MaterialTheme.colorScheme.primary.copy(alpha = 0.12f))
+                        .padding(horizontal = 6.dp, vertical = 2.dp)
+                )
+            }
+        }
+        Spacer(Modifier.height(9.dp))
+        Column(verticalArrangement = Arrangement.spacedBy(9.dp)) {
+            breakdown.parts.forEach { part ->
+                ModernContextPartRow(part, breakdown.estimatedTokens)
+            }
+        }
+        if (liveRunning) {
+            Spacer(Modifier.height(7.dp))
+            Text(
+                stringResource(R.string.chat_agent_context_live_hint),
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}
+
+@Composable
+private fun ModernContextPartRow(part: ContextPart, totalTokens: Int) {
+    val color = part.type.displayColor(MaterialTheme.colorScheme)
+    val share = if (totalTokens > 0) part.estimatedTokens.toFloat() / totalTokens else 0f
+    val percent = (share * 100).toInt()
+    Column {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Box(
+                modifier = Modifier
+                    .size(8.dp)
+                    .clip(CircleShape)
+                    .background(color)
+            )
+            Spacer(Modifier.width(8.dp))
+            Text(
+                contextPartLabel(part.type),
+                modifier = Modifier.weight(1f),
+                style = MaterialTheme.typography.bodySmall,
+                fontWeight = FontWeight.Medium,
+                maxLines = 1
+            )
+            Text(
+                stringResource(
+                    R.string.chat_context_analysis_part_detail,
+                    part.estimatedTokens,
+                    part.itemCount
+                ),
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Spacer(Modifier.width(8.dp))
+            Text(
+                "$percent%",
+                style = MaterialTheme.typography.labelSmall,
+                color = color,
+                fontWeight = FontWeight.Bold
+            )
+        }
+        Spacer(Modifier.height(4.dp))
+        LinearProgressIndicator(
+            progress = { share },
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(5.dp)
+                .clip(CircleShape),
+            color = color,
+            trackColor = MaterialTheme.colorScheme.surfaceVariant
+        )
     }
 }
 

--- a/app/src/main/res/values-en/strings_chat.xml
+++ b/app/src/main/res/values-en/strings_chat.xml
@@ -613,6 +613,13 @@
     <string name="chat_context_analysis_system_prompt">System prompt</string>
     <string name="chat_context_analysis_tool_content">Tool calls</string>
     <string name="chat_context_analysis_other_messages">Other messages</string>
+
+    <string name="chat_agent_status_preparing">Preparing…</string>
+    <string name="chat_agent_status_thinking">Thinking…</string>
+    <string name="chat_agent_status_tool_running">Tool: %1$s</string>
+    <string name="chat_context_live_badge">LIVE</string>
+    <string name="chat_agent_context_live_desc">Agent running — usage and breakdown update live</string>
+    <string name="chat_agent_context_live_hint">Agent running: usage and breakdown update live with thinking and tool calls</string>
     <string name="chat_queue_title">Queued messages (%1$d)</string>
     <string name="chat_queue_send_now">Send now</string>
     <string name="chat_queue_remove">Remove</string>

--- a/app/src/main/res/values-ja/strings_chat.xml
+++ b/app/src/main/res/values-ja/strings_chat.xml
@@ -614,6 +614,13 @@
     <string name="chat_context_analysis_system_prompt">システムプロンプト</string>
     <string name="chat_context_analysis_tool_content">ツール呼び出し</string>
     <string name="chat_context_analysis_other_messages">その他のメッセージ</string>
+
+    <string name="chat_agent_status_preparing">準備中…</string>
+    <string name="chat_agent_status_thinking">考え中…</string>
+    <string name="chat_agent_status_tool_running">ツール実行: %1$s</string>
+    <string name="chat_context_live_badge">リアルタイム</string>
+    <string name="chat_agent_context_live_desc">Agent 実行中、使用率と分析をリアルタイム更新</string>
+    <string name="chat_agent_context_live_hint">Agent 実行中: 使用率と分析は思考・ツール呼び出しに合わせてリアルタイム更新されます</string>
     <string name="chat_queue_title">送信待ちメッセージ（%1$d）</string>
     <string name="chat_queue_send_now">今すぐ送信</string>
     <string name="chat_queue_remove">削除</string>

--- a/app/src/main/res/values-ko/strings_chat.xml
+++ b/app/src/main/res/values-ko/strings_chat.xml
@@ -614,6 +614,13 @@
     <string name="chat_context_analysis_system_prompt">시스템 프롬프트</string>
     <string name="chat_context_analysis_tool_content">도구 호출</string>
     <string name="chat_context_analysis_other_messages">기타 메시지</string>
+
+    <string name="chat_agent_status_preparing">준비 중…</string>
+    <string name="chat_agent_status_thinking">생각 중…</string>
+    <string name="chat_agent_status_tool_running">도구 호출 · %1$s</string>
+    <string name="chat_context_live_badge">실시간</string>
+    <string name="chat_agent_context_live_desc">Agent 실행 중, 사용량과 분석이 실시간 업데이트됩니다</string>
+    <string name="chat_agent_context_live_hint">Agent 실행 중: 사용량·분석이 사고와 도구 호출에 따라 실시간 업데이트됩니다</string>
     <string name="chat_queue_title">대기 중인 메시지 (%1$d)</string>
     <string name="chat_queue_send_now">지금 보내기</string>
     <string name="chat_queue_remove">삭제</string>

--- a/app/src/main/res/values/strings_chat.xml
+++ b/app/src/main/res/values/strings_chat.xml
@@ -619,6 +619,13 @@
     <string name="chat_context_analysis_system_prompt">系统提示词</string>
     <string name="chat_context_analysis_tool_content">工具调用</string>
     <string name="chat_context_analysis_other_messages">其他消息</string>
+
+    <string name="chat_agent_status_preparing">准备中…</string>
+    <string name="chat_agent_status_thinking">思考中…</string>
+    <string name="chat_agent_status_tool_running">调用工具 · %1$s</string>
+    <string name="chat_context_live_badge">实时</string>
+    <string name="chat_agent_context_live_desc">Agent 运行中，占比与分析实时更新</string>
+    <string name="chat_agent_context_live_hint">Agent 运行中：占比与分析随思考/工具调用实时更新</string>
     <string name="chat_queue_title">排队消息（%1$d）</string>
     <string name="chat_queue_send_now">立即发送</string>
     <string name="chat_queue_remove">移除</string>


### PR DESCRIPTION
## 背景

Agent 会话中，模型持续思考与调用工具时，本轮新增的助手/工具消息要等整轮结束才落库（`saveAssistantMessage`）。因此 `+` 菜单里的上下文占比与类型分析会一直停留在旧值，无法反映真实上下文增长。

## 改动

1. **轮询刷新**：`+` 菜单上下文卡片在 Agent 生成期间每 2s 重算一次（原仅在消息数量/压缩边界/发送状态变化时刷新），普通会话保持单次刷新、行为不变。
2. **运行中占用估算**：新增 `AgentLiveContextUsage`（LocalRepository / UnifiedRepository 透出），在 `sessionContextTokenUsage` 基础上叠加 `agent_run` 检查点中尚未落库、但会随 tool_call_history 注入下一轮请求的工具调用历史估算，占比随工具步骤实时增长。
3. **+ 菜单内联分析**：`ModernContextCard` 新增「类型占比」区块（实时徽标 + 各类型 token/项数/百分比条），数据与全屏分析页同源（`buildContextBreakdown` + 新增 `withLiveToolTokens` 合并）。
4. **实时状态**：状态栏展示 Agent 阶段（准备中 / 思考中 / 调用工具 · 名称），来自 agent_run 的 stage/last_tool_name。
5. **全屏分析页同步**：`ContextAnalysisScreen` 加载时同样合并运行中工具占用，与 `+` 面板口径一致。
6. 补充 zh/en/ja/ko 多语言文案。

## 验证

- 静态校验：4 语言字符串引用齐全、XML 合法无重复、函数参数与括号平衡检查通过。
- 本环境无 JDK，未执行 Gradle 编译，请以 CI / 本地编译为准。