### PR TITLE
fix(worldbook): 删除世界书后自动刷新列表

### DIFF
--- a/app/src/main/kotlin/com/nekobot/app/ui/screens/worldbook/WorldBookDetailScreen.kt
+++ b/app/src/main/kotlin/com/nekobot/app/ui/screens/worldbook/WorldBookDetailScreen.kt
@@ -440,7 +440,8 @@ class WorldBookViewModel(bookId: String) : com.nekobot.app.ui.BaseViewModel() {
 @Composable
 fun WorldBookDetailScreen(
     bookId: String,
-    onBack: () -> Unit
+    onBack: () -> Unit,
+    onBookDeleted: (() -> Unit)? = null
 ) {
     val vm: WorldBookViewModel = viewModel(
         key = "wb_$bookId",
@@ -608,7 +609,10 @@ fun WorldBookDetailScreen(
             cancelText = stringResource(R.string.common_cancel),
             onConfirm = {
                 showDeleteBookDialog = false
-                vm.deleteBook(onBack)
+                vm.deleteBook {
+                    onBookDeleted?.invoke()
+                    onBack()
+                }
             },
             onCancel = { showDeleteBookDialog = false }
         )

--- a/app/src/main/kotlin/com/nekobot/app/ui/screens/worldbook/WorldBooksScreen.kt
+++ b/app/src/main/kotlin/com/nekobot/app/ui/screens/worldbook/WorldBooksScreen.kt
@@ -1,6 +1,7 @@
 package com.nekobot.app.ui.screens.worldbook
 
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.compose.LifecycleResumeEffect
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -146,6 +147,13 @@ fun WorldBooksScreen(
     // 模式切换时自动刷新世界书列表
     val appMode by ServiceContainer.appModeFlow.collectAsStateWithLifecycle()
     LaunchedEffect(appMode) { viewModel.load() }
+
+    // 从详情页返回（如删除世界书后 popBack）或重新回到前台时自动刷新列表，
+    // 避免列表仍展示已删除/已修改的旧数据
+    LifecycleResumeEffect(Unit) {
+        viewModel.load()
+        onPauseOrDispose { }
+    }
 
     // 双栏布局状态：大屏模式下选中的世界书 ID
     val useTwoPane = rememberShouldUseTwoPane()
@@ -313,7 +321,8 @@ fun WorldBooksScreen(
                 selectedBookId?.let { bookId ->
                     WorldBookDetailScreen(
                         bookId = bookId,
-                        onBack = { selectedBookId = null }
+                        onBack = { selectedBookId = null },
+                        onBookDeleted = { viewModel.load() }
                     )
                 } ?: Box(
                     modifier = Modifier.fillMaxSize(),


### PR DESCRIPTION
## 问题

在详情页删除世界书成功后，仅执行 `popBackStack` 返回列表页；列表页 `WorldBooksViewModel` 中缓存的列表不会更新，仍显示已删除的世界书（点击还会报错）。

## 根因

- 详情页删除成功后只调用 `onBack()`，没有通知列表页刷新；
- 列表页只在 `appMode` 变化或手动点击刷新按钮时才重新加载。

## 修复

1. **WorldBookDetailScreen**：新增可选回调 `onBookDeleted`，删除成功时先通知调用方再执行 `onBack`（默认 `null`，不影响现有调用方）。
2. **WorldBooksScreen（单栏导航）**：使用 `LifecycleResumeEffect` 在页面重新回到前台（从详情页返回）时自动 `viewModel.load()`，同时顺带覆盖详情页改名等场景。
3. **WorldBooksScreen（双栏布局）**：内嵌详情页传入 `onBookDeleted = { viewModel.load() }`，删除成功后立即刷新列表。

## 验证

- 单栏：详情页删除 → 返回列表 → 列表自动刷新，已删除的书不再出现。
- 双栏：大屏详情删除 → 右侧关闭、左侧列表立即刷新。
- 静态检查通过；本环境无 Android SDK，未执行 Gradle 编译。