### PR TITLE
fix(chat): Agent 实时记录完成后隐藏 + 面板类型占比

### DIFF
--- a/app/src/main/kotlin/com/nekobot/app/ui/screens/chat/ModernChatScreen.kt
+++ b/app/src/main/kotlin/com/nekobot/app/ui/screens/chat/ModernChatScreen.kt
@@ -2719,7 +2719,9 @@ private fun ModernContextCard(
                     modifier = Modifier.weight(1f)
                 )
             }
-            if (contextBreakdown?.parts?.isNotEmpty() == true) {
+            // 类型占比仅在 Agent 实时记录期间展示（随轮询动态刷新，含 LIVE 徽标）；
+            // 实时记录完成后自动隐藏，不再持续显示静态占比，仅保留上方的分析二级入口。
+            if (liveRunning && contextBreakdown?.parts?.isNotEmpty() == true) {
                 Spacer(Modifier.height(12.dp))
                 ModernContextAnalysisSection(
                     breakdown = contextBreakdown,


### PR DESCRIPTION
## 问题

+ 菜单内的 token 类型占比（上下文构成分析）在 Agent 实时记录（live 轮询）结束后仍持续显示静态数据，一直占用面板空间；实时记录期间应有的"实时"语义结束后不再有意义。

## 修改

`ModernContextCard` 中类型占比区块的显示条件增加 `liveRunning`：

- Agent 实时记录期间：占比随 2s 轮询动态刷新，带 LIVE 徽标与实时提示（行为不变）；
- 实时记录完成后（sending 结束 / 无活跃 Agent 运行）：占比区块自动隐藏，不再持续显示；
- 上方的上下文分析二级入口保留：点击圆环进度行仍可进入完整分析页 `ContextAnalysisScreen`。

改动 1 个文件（+3/-1），无新增资源。

## 验证

- 静态检查通过；本环境无 Android SDK，未执行 Gradle 编译。