### PR TITLE
fix(agent): 文件变更面板支持共享工作区及其他沙箱路径

### DIFF
--- a/app/src/main/kotlin/com/nekobot/app/data/local/WorkspaceGitDiff.kt
+++ b/app/src/main/kotlin/com/nekobot/app/data/local/WorkspaceGitDiff.kt
@@ -64,7 +64,8 @@ object WorkspaceGitDiff {
      * 汇总工作区内被修改文件的 Git 差异摘要。
      *
      * @param workspace 会话工作区根目录
-     * @param changedPaths 相对 workspace 的改动路径（AI 本轮实际写入/删除的文件）
+     * @param changedPaths 改动路径：相对 workspace 的相对路径，或实际文件绝对路径
+     *   （如共享工作区 shared:// 解析后的真实路径 / 其他沙箱内路径），二者可混用
      * @return 非 git 仓库 / 无净变化时返回 null（调用方不渲染卡片）
      */
     fun summarize(workspace: File, changedPaths: Collection<String>): GitDiffSummary? {
@@ -85,14 +86,17 @@ object WorkspaceGitDiff {
     ): GitDiffSummary? {
         val wsRoot = runCatching { workspace.canonicalFile }.getOrNull() ?: workspace.absoluteFile
 
-        // 1. 按文件所在 git 仓库分组（支持工作区嵌套仓库 / 工作区位于仓库子目录）
+        // 1. 按文件所在 git 仓库分组（支持工作区嵌套仓库 / 工作区位于仓库子目录 /
+        //    绝对路径直达共享工作区或其他沙箱内的仓库）
         val byRepo = LinkedHashMap<File, MutableList<File>>()
         for (relative in changedPaths) {
             val rel = relative.trim().replace('\\', '/').removePrefix("./")
             if (rel.isBlank()) continue
             // 忽略 .git 内部写入
             if (rel == ".git" || rel.startsWith(".git/")) continue
-            val file = File(wsRoot, rel)
+            // 绝对路径（共享工作区 / 其他沙箱解析后的真实路径）原样使用；
+            // 相对路径按 workspace 根解析。
+            val file = if (rel.startsWith("/")) File(rel) else File(wsRoot, rel)
             val parent = file.parentFile ?: wsRoot
             val gitRoot = findGitRoot(parent, FIND_GIT_ROOT_DEPTH) ?: continue
             val canonicalRoot = runCatching { gitRoot.canonicalFile }.getOrElse { gitRoot.absoluteFile }

--- a/app/src/main/kotlin/com/nekobot/app/data/local/ai/LocalAgentToolExecutor.kt
+++ b/app/src/main/kotlin/com/nekobot/app/data/local/ai/LocalAgentToolExecutor.kt
@@ -1285,16 +1285,16 @@ internal class LocalAgentToolExecutor(
 
     /**
      * 工作区文件快照：相对路径 → (size, lastModified)。
-     * 仅覆盖会话工作区（exec 沙盒挂载点）；跳过 .git 内部，避免把仓库元数据当变更。
+     * 覆盖会话工作区（exec 沙盒挂载点）与共享工作区两个根；共享工作区文件以
+     * shared:// 前缀记录，与 workspace_* 工具的相对路径语义一致。
+     * 跳过 .git 内部，避免把仓库元数据当变更。
      * 大数据量时截断扫描，保证 exec 高频调用不卡顿。
      */
     internal fun snapshotWorkspaceFiles(): Map<String, Pair<Long, Long>> {
-        val root = workspace ?: return emptyMap()
-        if (!root.isDirectory) return emptyMap()
         val result = LinkedHashMap<String, Pair<Long, Long>>()
         val MAX_SNAPSHOT_FILES = 20_000
         val MAX_SNAPSHOT_DEPTH = 24
-        fun walk(dir: File, prefix: String, depth: Int) {
+        fun walk(dir: File, prefix: String, depth: Int, shared: Boolean) {
             if (result.size >= MAX_SNAPSHOT_FILES || depth > MAX_SNAPSHOT_DEPTH) return
             val children = dir.listFiles() ?: return
             for (child in children) {
@@ -1302,14 +1302,16 @@ internal class LocalAgentToolExecutor(
                 val name = child.name
                 if (name == ".git") continue
                 val rel = if (prefix.isEmpty()) name else "$prefix/$name"
+                val key = if (shared) "shared://$rel" else rel
                 if (child.isDirectory) {
-                    walk(child, rel, depth + 1)
+                    walk(child, rel, depth + 1, shared)
                 } else if (child.isFile) {
-                    result[rel] = child.length() to child.lastModified()
+                    result[key] = child.length() to child.lastModified()
                 }
             }
         }
-        walk(root, "", 0)
+        workspace?.takeIf { it.isDirectory }?.let { walk(it, "", 0, false) }
+        sharedWorkspace?.takeIf { it.isDirectory }?.let { walk(it, "", 0, true) }
         return result
     }
 
@@ -1331,8 +1333,8 @@ internal class LocalAgentToolExecutor(
     fun currentChangedPaths(): Set<String> = changedPaths.toSet()
 
     /**
-     * 计算当前工作区在已变更路径上的 git 变更摘要。
-     * - 仅本地 Agent 模式、且工作区位于 git 追踪目录时才返回非空。
+     * 计算已变更文件（会话工作区 / 共享工作区 / 绝对路径）的 git 变更摘要。
+     * - 仅本地 Agent 模式、且变更文件位于 git 追踪目录时才返回非空。
      * - 无变更路径、无可追踪 git 仓库或 HEAD 缺失时返回 null（UI 不渲染）。
      * 内部自行容错，绝不会抛异常。
      */
@@ -1340,9 +1342,34 @@ internal class LocalAgentToolExecutor(
         val root = workspace ?: return null
         if (changedPaths.isEmpty()) return null
         return try {
-            WorkspaceGitDiff.summarize(root, changedPaths.toList())
+            // changedPaths 可能是 workspace 相对路径、shared:// 前缀路径或绝对路径，
+            // 统一解析为实际文件后交给差异引擎，保证共享工作区等沙箱外变更也能出卡片
+            val files = changedPaths.mapNotNull { resolveChangedFile(it) }
+            if (files.isEmpty()) return null
+            WorkspaceGitDiff.summarize(root, files.map { it.canonicalPath })
         } catch (e: Exception) {
             null
+        }
+    }
+
+    /** 把已记录的变更路径（相对路径 / shared:// 前缀 / 绝对路径）解析为实际文件。 */
+    private fun resolveChangedFile(path: String): File? {
+        val trimmed = path.trim()
+        if (trimmed.isEmpty() || trimmed == ".") return null
+        return when {
+            trimmed.startsWith("shared://", ignoreCase = true) -> {
+                val shared = sharedWorkspace ?: return null
+                val rel = trimmed.removePrefix("shared://")
+                    .replace('\\', '/')
+                    .removePrefix("/")
+                if (rel.isBlank()) return null
+                File(shared, rel).canonicalFile
+            }
+            trimmed.startsWith("/") -> File(trimmed).canonicalFile
+            else -> {
+                val root = workspace ?: return null
+                File(root, trimmed.removePrefix("/workspace/")).canonicalFile
+            }
         }
     }
 

--- a/app/src/test/kotlin/com/nekobot/app/data/local/WorkspaceGitDiffTest.kt
+++ b/app/src/test/kotlin/com/nekobot/app/data/local/WorkspaceGitDiffTest.kt
@@ -185,6 +185,58 @@ class WorkspaceGitDiffTest {
         assertNull("无变更应返回 null", WorkspaceGitDiff.summarize(ws, emptyList()))
     }
 
+    @Test
+    fun absolutePathsOutsideWorkspaceProduceSummary() {
+        // 模拟共享工作区：仓库位于会话工作区之外的独立根目录
+        val sharedRoot = newTempDir()
+        val ws = newTempDir()
+        val gitDir = File(sharedRoot, ".git")
+        initRepo(gitDir, mapOf("src/a.py" to "line1\nline2\n".toByteArray(Charsets.UTF_8)))
+
+        // 工作区外的仓库文件被修改 / 新增（AI 编辑共享工作区文件）
+        val target = File(sharedRoot, "src/a.py")
+        target.writeText("line1 changed\nline2\n", Charsets.UTF_8)
+        val added = File(sharedRoot, "src/b.py")
+        added.writeText("brand new\n", Charsets.UTF_8)
+
+        // changedPaths 传入真实绝对路径，workspace 参数指向会话工作区
+        val summary = WorkspaceGitDiff.summarize(
+            ws,
+            listOf(target.canonicalPath, added.canonicalPath)
+        )
+        assertNotNull("绝对路径（共享工作区）应生成 git 摘要", summary)
+        val s = summary!!
+        val a = s.files.first { it.path == "src/a.py" }
+        assertEquals(GitDiffFile.STATUS_MODIFIED, a.status)
+        assertTrue("a.py 应有新增行", a.additions > 0)
+        val b = s.files.first { it.path == "src/b.py" }
+        assertEquals(GitDiffFile.STATUS_ADDED, b.status)
+        assertTrue(b.hunks.flatMap { it.lines }.any { it.kind == GitDiffLine.KIND_ADD && it.text == "brand new" })
+    }
+
+    @Test
+    fun mixedRelativeAndAbsolutePathsPickLargestRepo() {
+        // 相对路径（会话工作区仓库）与绝对路径（共享工作区仓库）混用时，
+        // 应正确解析各自仓库并按文件数取覆盖最多的仓库生成单张摘要
+        val ws = newTempDir()
+        val wsGit = File(ws, ".git")
+        initRepo(wsGit, mapOf("keep.txt" to "x\n".toByteArray(Charsets.UTF_8)))
+        File(ws, "keep.txt").writeText("x changed\n", Charsets.UTF_8)
+
+        val sharedRoot = newTempDir()
+        val sharedGit = File(sharedRoot, ".git")
+        initRepo(sharedGit, mapOf("only.txt" to "y\n".toByteArray(Charsets.UTF_8)))
+        File(sharedRoot, "only.txt").writeText("y changed\n", Charsets.UTF_8)
+
+        // 相对 + 绝对混合，两者各 1 个变更文件 → 取 first（相对路径仓库）
+        val summary = WorkspaceGitDiff.summarize(
+            ws,
+            listOf("keep.txt", File(sharedRoot, "only.txt").canonicalPath)
+        )
+        assertNotNull(summary)
+        assertEquals("keep.txt", summary!!.files.single().path)
+    }
+
     // ---------- 纯逻辑单测 ----------
 
     @Test

--- a/app/src/test/kotlin/com/nekobot/app/data/local/ai/LocalAgentGitTrackingTest.kt
+++ b/app/src/test/kotlin/com/nekobot/app/data/local/ai/LocalAgentGitTrackingTest.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.runBlocking
 import org.junit.Test
 import java.io.File
 import java.nio.file.Files
+import com.nekobot.app.data.local.toHex
 
 /**
  * 验证 LocalAgentToolExecutor 对文件变更工具的路径追踪，以及 git 摘要生成。
@@ -110,5 +111,112 @@ class LocalAgentGitTrackingTest {
         assertTrue("修改文件应被追踪", changed.contains("pre.txt"))
         assertTrue("删除文件应被追踪", changed.contains("gone.txt"))
         assertTrue("无关文件不应被追踪", !changed.contains("unrelated.txt"))
+    }
+
+    @Test
+    fun sharedWorkspaceChangesTrackedAndSummarized() = runBlocking {
+        val ws = Files.createTempDirectory("wgt").toFile()
+        val shared = Files.createTempDirectory("wgt-shared").toFile()
+        root = ws
+        val executor = LocalAgentToolExecutor(
+            sessionId = "session-git-shared",
+            workspaceRoot = ws,
+            sharedWorkspaceRoot = shared,
+            authorizationManager = LocalExecAuthorizationManager(100),
+            onConfirmationRequired = {},
+            thinkingHistoryProvider = { emptyList() }
+        )
+        // 共享工作区预置一个 git 仓库（HEAD 含 main.py）
+        initGitRepo(File(shared, ".git"), mapOf("main.py" to "print(1)\n".toByteArray(Charsets.UTF_8)))
+
+        // AI 通过 shared:// 前缀编辑共享工作区文件
+        val edited = executor.execute(
+            "workspace_edit_file",
+            mapOf(
+                "path" to "shared://main.py",
+                "old_string" to "print(1)",
+                "new_string" to "print(2)"
+            )
+        )
+        assertEquals(true, edited["success"])
+        assertTrue("shared:// 变更应被追踪", executor.currentChangedPaths().contains("shared://main.py"))
+
+        // 快照覆盖共享工作区（shared:// 前缀）
+        val snap = executor.snapshotWorkspaceFiles()
+        assertTrue("快照应包含共享工作区文件", snap.containsKey("shared://main.py"))
+
+        // 共享工作区仓库上的变更应能生成 git 摘要（回归：此前只查当前工作区返回 null）
+        val summary = executor.currentGitDiffSummary()
+        assertNotNull("共享工作区变更应生成 git 摘要", summary)
+        val f = summary!!.files.first { it.path == "main.py" }
+        assertEquals(com.nekobot.app.data.model.GitDiffFile.STATUS_MODIFIED, f.status)
+    }
+
+    // ---------- 手工构造 git loose object 仓库（shared 场景测试用） ----------
+
+    private fun sha1(bytes: ByteArray): String {
+        val d = java.security.MessageDigest.getInstance("SHA-1")
+        return d.digest(bytes).toHex()
+    }
+
+    private fun zlibDeflate(bytes: ByteArray): ByteArray {
+        val deflater = java.util.zip.Deflater()
+        try {
+            deflater.setInput(bytes)
+            deflater.finish()
+            val bos = java.io.ByteArrayOutputStream()
+            val buf = ByteArray(8192)
+            while (!deflater.finished()) {
+                val n = deflater.deflate(buf)
+                bos.write(buf, 0, n)
+            }
+            return bos.toByteArray()
+        } finally {
+            deflater.end()
+        }
+    }
+
+    private fun hexDecode(hex: String): ByteArray {
+        val out = ByteArray(hex.length / 2)
+        for (i in out.indices) {
+            val hi = Character.digit(hex[i * 2], 16)
+            val lo = Character.digit(hex[i * 2 + 1], 16)
+            out[i] = ((hi shl 4) or lo).toByte()
+        }
+        return out
+    }
+
+    private fun writeLooseObject(gitDir: File, type: String, content: ByteArray): String {
+        val header = "$type ${content.size}\u0000".toByteArray(Charsets.US_ASCII)
+        val sha = sha1(header + content)
+        val dir = File(gitDir, "objects/${sha.substring(0, 2)}")
+        dir.mkdirs()
+        File(dir, sha.substring(2)).writeBytes(zlibDeflate(header + content))
+        return sha
+    }
+
+    private fun initGitRepo(gitDir: File, files: Map<String, ByteArray>) {
+        File(gitDir, "objects/info").mkdirs()
+        File(gitDir, "objects/pack").mkdirs()
+        File(gitDir, "refs/heads").mkdirs()
+
+        val workspace = gitDir.parentFile
+        val treeContent = java.io.ByteArrayOutputStream()
+        for (name in files.keys.sorted()) {
+            val content = files.getValue(name)
+            val blobSha = writeLooseObject(gitDir, "blob", content)
+            treeContent.write(
+                ("100644 $name").toByteArray(Charsets.US_ASCII) + byteArrayOf(0) + hexDecode(blobSha)
+            )
+            val target = File(workspace, name)
+            target.parentFile?.mkdirs()
+            target.writeBytes(content)
+        }
+        val treeSha = writeLooseObject(gitDir, "tree", treeContent.toByteArray())
+        val commitBody = ("tree $treeSha\nauthor Test <t@t> 1700000000 +0800\n" +
+            "committer Test <t@t> 1700000000 +0800\n\ninitial\n").toByteArray(Charsets.UTF_8)
+        val commitSha = writeLooseObject(gitDir, "commit", commitBody)
+        File(gitDir, "refs/heads/main").writeText(commitSha + "\n", Charsets.UTF_8)
+        File(gitDir, "HEAD").writeText("ref: refs/heads/main\n", Charsets.UTF_8)
     }
 }


### PR DESCRIPTION
## 问题

进度卡片的文件变更面板（git 变更摘要）只把 changedPaths 当作**当前会话工作区**的相对路径解析。AI 编辑共享工作区（`shared://`）或 exec 沙盒内其他路径的文件时：

- `shared://xxx` 被当作相对路径拼到 workspace 下 → 文件不存在 → 找不到 git 仓库 → 摘要为 null；
- exec 前后快照只扫描会话工作区 → 共享工作区变更根本不会被追踪。

最终表现为：AI 改了共享工作区的代码，但进度卡片上没有文件变更面板。

## 修改

1. **WorkspaceGitDiff.summarize**：changedPaths 支持相对路径与**绝对路径混用**（`/` 开头原样使用，否则按 workspace 根解析），可直达共享工作区/其他沙箱内的 git 仓库。
2. **LocalAgentToolExecutor**：
   - `currentGitDiffSummary` 把 changedPaths（相对路径 / `shared://` 前缀 / 绝对路径）统一解析为实际文件后生成摘要；
   - `snapshotWorkspaceFiles` 扩展到**会话工作区 + 共享工作区**双根扫描，共享工作区文件以 `shared://` 前缀记录（与 workspace_* 工具语义一致），exec 内编辑共享工作区文件也能被追踪。
3. **测试**：`WorkspaceGitDiffTest` 新增绝对路径、相对+绝对混用用例；`LocalAgentGitTrackingTest` 新增 shared:// 端到端追踪与摘要用例。

改动 4 个文件（+204/-13），无新增资源。

## 验证

- 静态检查通过；本环境无 JDK/Android SDK，未运行 Gradle 测试与编译，建议 CI 或本地执行 `testDebugUnitTest` 确认。