### PR TITLE
fix(chat): 排队消息立即发送时不再产生第二个进度卡片

### DIFF
--- a/app/src/main/kotlin/com/nekobot/app/ui/screens/chat/ChatScreen.kt
+++ b/app/src/main/kotlin/com/nekobot/app/ui/screens/chat/ChatScreen.kt
@@ -4963,7 +4963,7 @@ internal fun mergeRealtimeNewMessage(
         val optimisticIndex = if (isSending) {
             normalizedCurrent.indexOfLast {
                 it.isUser &&
-                    it.id.isNullOrBlank() &&
+                    (it.id.isNullOrBlank() || isUrgentBubbleId(it.id)) &&
                     it.content == incoming.content
             }
         } else {
@@ -5815,10 +5815,47 @@ internal fun buildChatMessageContent(
 }
 
 /**
+ * 判断消息是否为排队消息“立即发送”的乐观气泡（等待注入/直发期间显示）。
+ */
+internal fun isUrgentBubbleId(id: String?): Boolean =
+    id?.startsWith(ChatViewModel.URGENT_BUBBLE_PREFIX) == true
+
+/**
+ * 将排队消息“立即发送”的乐观气泡插入消息流。
+ *
+ * 统一放在当前 AI 处理进度卡片（最后一条带进度卡片的用户消息）的上方，
+ * 多条插队消息按 FIFO 依次排列在已有插队气泡之后；不存在进度卡片时
+ * 回退到最后一条用户消息之后。避免追加到列表末尾而出现在 AI 输出之下，
+ * 形成多余的“第二个进度卡片”。
+ */
+internal fun insertUrgentBubble(
+    messages: List<Message>,
+    bubble: Message
+): List<Message> {
+    if (messages.isEmpty()) return listOf(bubble)
+    // 已有插队气泡的最后一个（保持 FIFO 顺序：先插队在上方）
+    val lastUrgentIndex = messages.indexOfLast { isUrgentBubbleId(it.id) }
+    // 当前处理中的进度卡片所在用户消息：插队消息渲染在其上方（其 item 内渲染进度卡片）
+    val latestCardIndex = messages.indexOfLast {
+        it.isUser && !it.thinkingCards.isNullOrEmpty()
+    }
+    val insertIndex = when {
+        lastUrgentIndex >= 0 -> lastUrgentIndex + 1
+        latestCardIndex >= 0 -> latestCardIndex
+        else -> messages.indexOfLast { it.isUser } + 1
+    }
+    return messages.toMutableList().apply {
+        add(insertIndex.coerceIn(0, size), bubble)
+    }
+}
+
+/**
  * 将实时进度卡片挂到父用户消息。
  *
  * 本地发送先插入没有数据库 id 的乐观用户消息，因此按 parentMessageId 找不到时，
  * 回退到最后一条用户消息；同一卡片的后续百分比更新会原位替换。
+ * 回退时跳过排队“立即发送”的乐观气泡，避免新进度卡片挂到插队消息下
+ * 形成与原有进度卡片并存的“第二个进度卡片”。
  */
 internal fun attachThinkingCardToMessages(
     messages: List<Message>,
@@ -5830,7 +5867,7 @@ internal fun attachThinkingCardToMessages(
     val targetIndex = if (parentIndex >= 0) {
         parentIndex
     } else {
-        messages.indexOfLast { it.isUser }
+        messages.indexOfLast { it.isUser && !isUrgentBubbleId(it.id) }
     }
     if (targetIndex < 0) return messages
 

--- a/app/src/main/kotlin/com/nekobot/app/ui/screens/chat/ChatViewModel.kt
+++ b/app/src/main/kotlin/com/nekobot/app/ui/screens/chat/ChatViewModel.kt
@@ -228,6 +228,8 @@ class ChatViewModel : BaseViewModel() {
         const val STREAMING_ID = "_streaming_"
         /** 服务端持久化尚未刷新时使用的临时正式消息 id 前缀。 */
         const val STREAM_FALLBACK_PREFIX = "_stream_fallback_"
+        /** 排队消息“立即发送”乐观气泡的 id 前缀（本地注入/服务器直发期间显示）。 */
+        const val URGENT_BUBBLE_PREFIX = "_queued_urgent_"
     }
 
     private val socket = ServiceContainer.socket
@@ -1895,7 +1897,7 @@ class ChatViewModel : BaseViewModel() {
     // ==================== Agent 会话消息排队 ====================
 
     /** 排队消息“立即发送”的乐观气泡 id 前缀（本地注入/服务器直发期间显示） */
-    private fun queuedUrgentBubbleId(itemId: String) = "_queued_urgent_$itemId"
+    private fun queuedUrgentBubbleId(itemId: String) = "${URGENT_BUBBLE_PREFIX}$itemId"
 
     /**
      * 取出（并清空）请求“立即发送”的排队消息。
@@ -1954,22 +1956,30 @@ class ChatViewModel : BaseViewModel() {
         }
         if (isLocalMode) {
             // 注入进行中的本地 Agent 工具循环：乐观气泡 + 等待下一次模型调用前注入
-            _messages.value = _messages.value + Message(
-                id = queuedUrgentBubbleId(target.id),
-                role = "user",
-                content = buildChatMessageContent(target.content, target.attachments),
-                timestamp = System.currentTimeMillis().toString()
+            // 插入位置统一放在当前 AI 处理进度卡片（所在用户消息）的上方，多条插队消息按 FIFO 依次排列，
+            // 避免追加到列表末尾而落在 AI 输出之下、看起来像多出的新卡片。
+            _messages.value = insertUrgentBubble(
+                _messages.value,
+                Message(
+                    id = queuedUrgentBubbleId(target.id),
+                    role = "user",
+                    content = buildChatMessageContent(target.content, target.attachments),
+                    timestamp = System.currentTimeMillis().toString()
+                )
             )
             runtime.urgentMessages.add(target)
             showToast(string(R.string.chat_queue_injecting))
             return
         }
         // 服务器模式无法中途注入：直接经 Socket 发送
-        _messages.value = _messages.value + Message(
-            id = queuedUrgentBubbleId(target.id),
-            role = "user",
-            content = buildChatMessageContent(target.content, target.attachments),
-            timestamp = System.currentTimeMillis().toString()
+        _messages.value = insertUrgentBubble(
+            _messages.value,
+            Message(
+                id = queuedUrgentBubbleId(target.id),
+                role = "user",
+                content = buildChatMessageContent(target.content, target.attachments),
+                timestamp = System.currentTimeMillis().toString()
+            )
         )
         socket.sendMessage(
             currentSessionId,

--- a/app/src/test/kotlin/com/nekobot/app/ui/screens/chat/RealtimeMessageMergeTest.kt
+++ b/app/src/test/kotlin/com/nekobot/app/ui/screens/chat/RealtimeMessageMergeTest.kt
@@ -196,4 +196,83 @@ class RealtimeMessageMergeTest {
 
         assertEquals("服务端已经保存的更完整思考", merged.single().steps.single().thinkingContent)
     }
+
+    // ---- 排队消息“立即发送”乐观气泡 ----
+
+    private fun urgentBubble(content: String) = Message(
+        id = "${ChatViewModel.URGENT_BUBBLE_PREFIX}item-1",
+        role = "user",
+        content = content
+    )
+
+    private fun userWithCard(id: String, content: String) = Message(
+        id = id,
+        role = "user",
+        content = content,
+        thinkingCards = listOf(ThinkingCard(id = "card-$id", content = "处理中", isAgent = true))
+    )
+
+    @Test
+    fun urgentBubbleIsInsertedAboveTheLatestProgressCard() {
+        val history = Message(id = "old", role = "assistant", content = "旧回复")
+        val user = userWithCard("user-1", "当前问题")
+
+        val result = insertUrgentBubble(listOf(history, user), urgentBubble("插队消息"))
+
+        assertEquals(3, result.size)
+        // 插队消息位于进度卡片宿主消息（user-1）之前 → 渲染在进度卡片上方
+        assertEquals(ChatViewModel.URGENT_BUBBLE_PREFIX + "item-1", result[1].id)
+        assertEquals("user-1", result[2].id)
+    }
+
+    @Test
+    fun urgentBubblesKeepFifoOrderAboveProgressCard() {
+        val user = userWithCard("user-1", "当前问题")
+        val first = insertUrgentBubble(listOf(user), urgentBubble("先发送"))
+        val second = insertUrgentBubble(first, urgentBubble("后发送"))
+
+        assertEquals(3, second.size)
+        assertEquals(ChatViewModel.URGENT_BUBBLE_PREFIX + "item-1", second[0].id)
+        // 先插队的气泡保持在后面插队气泡的上方（FIFO：后插队的紧挨进度卡片）
+        assertEquals("后发送", second[1].content)
+        assertEquals("user-1", second[2].id)
+    }
+
+    @Test
+    fun urgentBubbleFallsBackToLatestUserMessageWhenNoProgressCard() {
+        val history = Message(id = "assistant-1", role = "assistant", content = "回复")
+        val user = Message(id = "user-1", role = "user", content = "问题")
+        val streaming = Message(
+            id = ChatViewModel.STREAMING_ID,
+            role = "assistant",
+            content = ""
+        )
+
+        val result = insertUrgentBubble(listOf(history, user, streaming), urgentBubble("插队消息"))
+
+        assertEquals(4, result.size)
+        assertEquals("user-1", result[1].id)
+        assertEquals(ChatViewModel.URGENT_BUBBLE_PREFIX + "item-1", result[2].id)
+        assertEquals(ChatViewModel.STREAMING_ID, result[3].id)
+    }
+
+    @Test
+    fun serverMessageReplacesUrgentBubbleInsteadOfDuplicating() {
+        val bubble = urgentBubble("插队消息")
+        val serverMessage = Message(
+            id = "server-user-1",
+            role = "user",
+            content = "插队消息",
+            sessionId = "session-a"
+        )
+
+        val merged = mergeRealtimeNewMessage(
+            current = listOf(bubble),
+            incoming = serverMessage,
+            isSending = true
+        )
+
+        assertEquals(1, merged.size)
+        assertEquals("server-user-1", merged.single().id)
+    }
 }

--- a/app/src/test/kotlin/com/nekobot/app/ui/screens/chat/ThinkingCardMessagesTest.kt
+++ b/app/src/test/kotlin/com/nekobot/app/ui/screens/chat/ThinkingCardMessagesTest.kt
@@ -44,6 +44,36 @@ class ThinkingCardMessagesTest {
     }
 
     @Test
+    fun cardFallbackSkipsUrgentBubbleSoNoSecondProgressCardAppears() {
+        val persistedUser = Message(
+            id = "persisted-user-1",
+            role = "user",
+            content = "当前问题",
+            thinkingCards = listOf(ThinkingCard(id = "card-1", content = "处理中", progress = 40))
+        )
+        // 排队消息“立即发送”的乐观气泡位于列表末尾（等待注入）
+        val urgentBubble = Message(
+            id = "${ChatViewModel.URGENT_BUBBLE_PREFIX}item-x",
+            role = "user",
+            content = "插队消息"
+        )
+        // 父消息 id 指向尚未落库的正式 id：UI 中匹配不到，必须回退到最后一条普通用户消息，
+        // 而不是回退到插队乐观气泡下形成第二个进度卡片
+        val card = ThinkingCard(
+            id = "card-2",
+            content = "继续处理中",
+            isAgent = true,
+            parentMessageId = "server-user-9"
+        )
+
+        val result = attachThinkingCardToMessages(listOf(persistedUser, urgentBubble), card)
+
+        // 新卡片与原有卡片一起挂在普通用户消息下，插队气泡不挂卡
+        assertEquals(listOf("card-1", "card-2"), result.first().thinkingCards?.map { it.id })
+        assertTrue(result.last().thinkingCards.isNullOrEmpty())
+    }
+
+    @Test
     fun replacesPreviousRealtimeUpdateForTheSameCard() {
         val first = ThinkingCard(id = "card-1", content = "下载中", progress = 20)
         val latest = first.copy(content = "继续下载", progress = 65)


### PR DESCRIPTION
## 问题

Agent 会话（本地/服务器模式）中，AI 生成期间发送的消息进入排队队列后，点击“立即发送”会出现**两个进度卡片**：

1. **乐观气泡追加到 `_messages` 末尾**：`sendQueuedNow` 使用 `_messages.value + Message(...)` 把插队消息追加到列表尾部。当 AI 正在流式输出（`STREAMING_ID` 占位已在列表中）时，插队消息会落在 AI 输出**之下**，视觉上像多出的新卡片。
2. **进度卡片回退挂载到插队气泡**：`attachThinkingCardToMessages` 按 `parentMessageId` 找不到父消息时回退到“最后一条用户消息”——插队乐观气泡（`_queued_urgent_*`）恰好是最后一条用户消息，新的 thinking_card 会挂到它下面，与原有进度卡片并存成“两个进度卡片”。
3. **服务器模式重复消息**：socket 回包（正式 id）不匹配乐观替换条件（仅匹配 `id.isNullOrBlank()`），同一插队消息显示两份。

## 修改

- `sendQueuedNow`：乐观气泡改为 `insertUrgentBubble` 插入——统一放在**当前 AI 处理进度卡片所在用户消息的上方**，多条插队消息按 FIFO 依次排列在已有插队气泡之后；无进度卡片时回退到最后一条用户消息之后
- `attachThinkingCardToMessages`：回退挂载时跳过插队乐观气泡，新进度卡片不再挂到插队消息下
- `mergeRealtimeNewMessage`：正式消息回包视为插队乐观气泡的原位替换（而非追加）
- 新增 `ChatViewModel.URGENT_BUBBLE_PREFIX` 常量；补充 `RealtimeMessageMergeTest` / `ThinkingCardMessagesTest` 单元测试（插入位置、FIFO 顺序、回退跳过、服务器替换）

## 验证

- 新增 5 个单元测试覆盖上述行为
- CI（`testDebugUnitTest lintDebug assembleDebug`）将自动运行