### PR TITLE
feat(chat): AI 气泡在 token 数旁展示生成速度 tok/s

### DIFF
--- a/app/schemas/com.nekobot.app.data.local.db.NekobotDatabase/39.json
+++ b/app/schemas/com.nekobot.app.data.local.db.NekobotDatabase/39.json
@@ -1,0 +1,2913 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 39,
+    "identityHash": "68be262d3181f330585d2ef691ec4ded",
+    "entities": [
+      {
+        "tableName": "local_sessions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `character_id` TEXT, `system_prompt` TEXT, `first_message` TEXT, `scenario` TEXT, `sender_name` TEXT, `sender_avatar` TEXT, `character_name` TEXT, `character_avatar` TEXT, `portrait` TEXT, `tags` TEXT, `favorite` INTEGER NOT NULL, `pinned` INTEGER NOT NULL, `archived` INTEGER NOT NULL, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL, `last_message` TEXT, `message_count` INTEGER NOT NULL, `plot_mode` INTEGER NOT NULL, `plot_realtime_sync` INTEGER NOT NULL, `plot_choice_style` TEXT, `plot_outline` TEXT, `user_persona` TEXT, `auto_state_interval` INTEGER NOT NULL, `disabled_prompt_keys` TEXT, `custom_prompts` TEXT, `prompt_stack_debug` TEXT, `composed_system_prompt` TEXT, `is_public` INTEGER NOT NULL, `proactive_chat` TEXT, `tts_config` TEXT, `share_config` TEXT, `archive_session_id` TEXT, `session_mode` TEXT NOT NULL DEFAULT 'character', `group_id` TEXT, `character_ids` TEXT, `group_config` TEXT, `group_active_speaker` TEXT, `group_turn_count` INTEGER NOT NULL DEFAULT 0, `agent_todos` TEXT, `agent_goal` TEXT, `agent_spec` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "characterId",
+            "columnName": "character_id",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "systemPrompt",
+            "columnName": "system_prompt",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "firstMessage",
+            "columnName": "first_message",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "scenario",
+            "columnName": "scenario",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "senderName",
+            "columnName": "sender_name",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "senderAvatar",
+            "columnName": "sender_avatar",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "characterName",
+            "columnName": "character_name",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "characterAvatar",
+            "columnName": "character_avatar",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "portrait",
+            "columnName": "portrait",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "tags",
+            "columnName": "tags",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "favorite",
+            "columnName": "favorite",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pinned",
+            "columnName": "pinned",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "archived",
+            "columnName": "archived",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastMessage",
+            "columnName": "last_message",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "messageCount",
+            "columnName": "message_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "plotMode",
+            "columnName": "plot_mode",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "plotRealTimeSync",
+            "columnName": "plot_realtime_sync",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "plotChoiceStyle",
+            "columnName": "plot_choice_style",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "plotOutline",
+            "columnName": "plot_outline",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "userPersona",
+            "columnName": "user_persona",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "autoStateInterval",
+            "columnName": "auto_state_interval",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "disabledPromptKeys",
+            "columnName": "disabled_prompt_keys",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "customPrompts",
+            "columnName": "custom_prompts",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "promptStackDebug",
+            "columnName": "prompt_stack_debug",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "composedSystemPrompt",
+            "columnName": "composed_system_prompt",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "isPublic",
+            "columnName": "is_public",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "proactiveChat",
+            "columnName": "proactive_chat",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "ttsConfig",
+            "columnName": "tts_config",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "shareConfig",
+            "columnName": "share_config",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "archiveSessionId",
+            "columnName": "archive_session_id",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "sessionMode",
+            "columnName": "session_mode",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'character'"
+          },
+          {
+            "fieldPath": "groupId",
+            "columnName": "group_id",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "characterIds",
+            "columnName": "character_ids",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "groupConfig",
+            "columnName": "group_config",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "groupActiveSpeaker",
+            "columnName": "group_active_speaker",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "groupTurnCount",
+            "columnName": "group_turn_count",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "agentTodos",
+            "columnName": "agent_todos",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "agentGoal",
+            "columnName": "agent_goal",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "agentSpec",
+            "columnName": "agent_spec",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "local_messages",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `session_id` TEXT NOT NULL, `role` TEXT NOT NULL, `content` TEXT NOT NULL, `reasoning_content` TEXT, `sender` TEXT, `timestamp` TEXT NOT NULL, `model` TEXT, `input_tokens` INTEGER, `output_tokens` INTEGER, `audio_url` TEXT, `audio_updated_at` TEXT, `created_at` TEXT NOT NULL, `thinking_cards` TEXT, `tool_call_history` TEXT, `source` TEXT, `knowledge_citations` TEXT, `routing_decision_id` TEXT, `duration_ms` REAL, PRIMARY KEY(`id`), FOREIGN KEY(`session_id`) REFERENCES `local_sessions`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessionId",
+            "columnName": "session_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "role",
+            "columnName": "role",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "reasoningContent",
+            "columnName": "reasoning_content",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "sender",
+            "columnName": "sender",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "model",
+            "columnName": "model",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "inputTokens",
+            "columnName": "input_tokens",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "outputTokens",
+            "columnName": "output_tokens",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "audioUrl",
+            "columnName": "audio_url",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "audioUpdatedAt",
+            "columnName": "audio_updated_at",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thinkingCards",
+            "columnName": "thinking_cards",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "toolCallHistory",
+            "columnName": "tool_call_history",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "knowledgeCitations",
+            "columnName": "knowledge_citations",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "routingDecisionId",
+            "columnName": "routing_decision_id",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "REAL",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_messages_session_id",
+            "unique": false,
+            "columnNames": [
+              "session_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_messages_session_id` ON `${TABLE_NAME}` (`session_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "local_sessions",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "session_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "local_message_images",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `session_id` TEXT NOT NULL, `message_id` TEXT NOT NULL, `prompt` TEXT NOT NULL, `reference_image_path` TEXT, `reference_image_mime_type` TEXT, `status` TEXT NOT NULL, `file_name` TEXT, `file_path` TEXT, `mime_type` TEXT, `model_id` TEXT, `model_name` TEXT, `error_message` TEXT, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessionId",
+            "columnName": "session_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "messageId",
+            "columnName": "message_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "prompt",
+            "columnName": "prompt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "referenceImagePath",
+            "columnName": "reference_image_path",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "referenceImageMimeType",
+            "columnName": "reference_image_mime_type",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileName",
+            "columnName": "file_name",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "filePath",
+            "columnName": "file_path",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "mimeType",
+            "columnName": "mime_type",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "modelId",
+            "columnName": "model_id",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "modelName",
+            "columnName": "model_name",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "errorMessage",
+            "columnName": "error_message",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_message_images_session_id",
+            "unique": false,
+            "columnNames": [
+              "session_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_message_images_session_id` ON `${TABLE_NAME}` (`session_id`)"
+          },
+          {
+            "name": "index_local_message_images_message_id",
+            "unique": false,
+            "columnNames": [
+              "message_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_message_images_message_id` ON `${TABLE_NAME}` (`message_id`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "local_agent_runs",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`session_id` TEXT NOT NULL, `run_id` TEXT NOT NULL, `user_message_id` TEXT NOT NULL, `prompt` TEXT NOT NULL, `attachments_json` TEXT, `status` TEXT NOT NULL, `stage` TEXT NOT NULL, `checkpoint_history` TEXT, `completed_tool_calls` INTEGER NOT NULL, `last_tool_name` TEXT, `last_error` TEXT, `assistant_message_id` TEXT, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL, PRIMARY KEY(`session_id`), FOREIGN KEY(`session_id`) REFERENCES `local_sessions`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sessionId",
+            "columnName": "session_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "runId",
+            "columnName": "run_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userMessageId",
+            "columnName": "user_message_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "prompt",
+            "columnName": "prompt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "attachmentsJson",
+            "columnName": "attachments_json",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "stage",
+            "columnName": "stage",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "checkpointHistory",
+            "columnName": "checkpoint_history",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "completedToolCalls",
+            "columnName": "completed_tool_calls",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastToolName",
+            "columnName": "last_tool_name",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "lastError",
+            "columnName": "last_error",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "assistantMessageId",
+            "columnName": "assistant_message_id",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "session_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_agent_runs_user_message_id",
+            "unique": false,
+            "columnNames": [
+              "user_message_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_agent_runs_user_message_id` ON `${TABLE_NAME}` (`user_message_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "local_sessions",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "session_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "local_characters",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `description` TEXT, `avatar` TEXT, `portrait` TEXT, `tags` TEXT, `basic_info` TEXT, `personality` TEXT, `scenario` TEXT, `first_message` TEXT, `alternate_greetings` TEXT, `example_dialogues` TEXT, `response_format` TEXT, `rules` TEXT, `state` TEXT, `system_prompt` TEXT, `greeting` TEXT, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "avatar",
+            "columnName": "avatar",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "portrait",
+            "columnName": "portrait",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "tags",
+            "columnName": "tags",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "basicInfo",
+            "columnName": "basic_info",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "personality",
+            "columnName": "personality",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "scenario",
+            "columnName": "scenario",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "firstMessage",
+            "columnName": "first_message",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "alternateGreetings",
+            "columnName": "alternate_greetings",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "exampleDialogues",
+            "columnName": "example_dialogues",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "responseFormat",
+            "columnName": "response_format",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "rules",
+            "columnName": "rules",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "systemPrompt",
+            "columnName": "system_prompt",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "greeting",
+            "columnName": "greeting",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "local_world_books",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `description` TEXT, `cover_url` TEXT, `character_id` TEXT, `enabled` INTEGER NOT NULL, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "cover_url",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "characterId",
+            "columnName": "character_id",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "enabled",
+            "columnName": "enabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "local_world_book_entries",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `book_id` TEXT NOT NULL, `keys` TEXT, `content` TEXT, `comment` TEXT, `enabled` INTEGER NOT NULL, `constant` INTEGER NOT NULL, `selective` INTEGER NOT NULL, `insertion_order` INTEGER NOT NULL, `priority` INTEGER NOT NULL, `position` TEXT, `case_sensitive` INTEGER NOT NULL, `display_index` INTEGER NOT NULL, `trigger_sources_json` TEXT, `state_triggers_json` TEXT, `match_mode` TEXT NOT NULL, `entry_type` TEXT NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`book_id`) REFERENCES `local_world_books`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookId",
+            "columnName": "book_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "keys",
+            "columnName": "keys",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "comment",
+            "columnName": "comment",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "enabled",
+            "columnName": "enabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "constant",
+            "columnName": "constant",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "selective",
+            "columnName": "selective",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "insertionOrder",
+            "columnName": "insertion_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "priority",
+            "columnName": "priority",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "caseSensitive",
+            "columnName": "case_sensitive",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayIndex",
+            "columnName": "display_index",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "triggerSourcesJson",
+            "columnName": "trigger_sources_json",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "stateTriggersJson",
+            "columnName": "state_triggers_json",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "matchMode",
+            "columnName": "match_mode",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entryType",
+            "columnName": "entry_type",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_world_book_entries_book_id",
+            "unique": false,
+            "columnNames": [
+              "book_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_world_book_entries_book_id` ON `${TABLE_NAME}` (`book_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "local_world_books",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "book_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "local_ai_models",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `protocol` TEXT NOT NULL, `provider` TEXT, `api_key` TEXT NOT NULL, `proxy_url` TEXT NOT NULL, `base_url` TEXT NOT NULL, `model` TEXT NOT NULL, `enabled` INTEGER NOT NULL, `purpose` TEXT NOT NULL, `priority` INTEGER NOT NULL, `active` INTEGER NOT NULL, `temperature` REAL, `max_tokens` INTEGER, `max_context_length` INTEGER, `top_p` REAL, `append_base_url_path` INTEGER NOT NULL, `supports_tools` INTEGER NOT NULL, `supports_reasoning` INTEGER NOT NULL, `supports_stream` INTEGER NOT NULL, `supports_vision` INTEGER NOT NULL, `tts_provider` TEXT NOT NULL, `tts_url` TEXT NOT NULL, `tts_model` TEXT NOT NULL, `tts_voice` TEXT NOT NULL, `tts_speed` REAL NOT NULL, `tts_pitch` REAL NOT NULL, `tts_volume` REAL NOT NULL, `tts_format` TEXT NOT NULL, `tts_upload_url` TEXT NOT NULL, `tts_headers` TEXT NOT NULL, `tts_body_template` TEXT NOT NULL, `tts_resource_id` TEXT NOT NULL, `tts_ref_audio` TEXT NOT NULL, `tts_user` TEXT NOT NULL, `language` TEXT NOT NULL, `stt_provider` TEXT NOT NULL, `stt_url` TEXT NOT NULL, `stt_model` TEXT NOT NULL, `stt_headers` TEXT NOT NULL, `dimensions` INTEGER NOT NULL, `size` TEXT NOT NULL, `prompt_template` TEXT NOT NULL, `created_at` TEXT NOT NULL, `token_limit_daily` INTEGER NOT NULL, `token_limit_weekly` INTEGER NOT NULL, `failover_timeout` INTEGER NOT NULL, `input_price` REAL, `output_price` REAL, `oauth_account_id` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "protocol",
+            "columnName": "protocol",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "provider",
+            "columnName": "provider",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "apiKey",
+            "columnName": "api_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "proxyUrl",
+            "columnName": "proxy_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "baseUrl",
+            "columnName": "base_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "model",
+            "columnName": "model",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "enabled",
+            "columnName": "enabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "purpose",
+            "columnName": "purpose",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "priority",
+            "columnName": "priority",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "active",
+            "columnName": "active",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "temperature",
+            "columnName": "temperature",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "maxTokens",
+            "columnName": "max_tokens",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "maxContextLength",
+            "columnName": "max_context_length",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "topP",
+            "columnName": "top_p",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "appendBaseUrlPath",
+            "columnName": "append_base_url_path",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "supportsTools",
+            "columnName": "supports_tools",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "supportsReasoning",
+            "columnName": "supports_reasoning",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "supportsStream",
+            "columnName": "supports_stream",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "supportsVision",
+            "columnName": "supports_vision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ttsProvider",
+            "columnName": "tts_provider",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ttsUrl",
+            "columnName": "tts_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ttsModel",
+            "columnName": "tts_model",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ttsVoice",
+            "columnName": "tts_voice",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ttsSpeed",
+            "columnName": "tts_speed",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ttsPitch",
+            "columnName": "tts_pitch",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ttsVolume",
+            "columnName": "tts_volume",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ttsFormat",
+            "columnName": "tts_format",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ttsUploadUrl",
+            "columnName": "tts_upload_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ttsHeaders",
+            "columnName": "tts_headers",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ttsBodyTemplate",
+            "columnName": "tts_body_template",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ttsResourceId",
+            "columnName": "tts_resource_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ttsRefAudio",
+            "columnName": "tts_ref_audio",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ttsUser",
+            "columnName": "tts_user",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "language",
+            "columnName": "language",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sttProvider",
+            "columnName": "stt_provider",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sttUrl",
+            "columnName": "stt_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sttModel",
+            "columnName": "stt_model",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sttHeaders",
+            "columnName": "stt_headers",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dimensions",
+            "columnName": "dimensions",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "size",
+            "columnName": "size",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "promptTemplate",
+            "columnName": "prompt_template",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tokenLimitDaily",
+            "columnName": "token_limit_daily",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tokenLimitWeekly",
+            "columnName": "token_limit_weekly",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "failoverTimeout",
+            "columnName": "failover_timeout",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "inputPrice",
+            "columnName": "input_price",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "outputPrice",
+            "columnName": "output_price",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "oauthAccountId",
+            "columnName": "oauth_account_id",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_ai_models_oauth_account_id",
+            "unique": false,
+            "columnNames": [
+              "oauth_account_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_ai_models_oauth_account_id` ON `${TABLE_NAME}` (`oauth_account_id`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "local_failover_health",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`model_id` TEXT NOT NULL, `consecutive_failures` INTEGER NOT NULL, `last_failure_code` INTEGER NOT NULL, `last_failure_at_ms` INTEGER NOT NULL, `cooldown_until_ms` INTEGER NOT NULL, `daily_failures` INTEGER NOT NULL, `daily_failures_date` TEXT NOT NULL, PRIMARY KEY(`model_id`))",
+        "fields": [
+          {
+            "fieldPath": "modelId",
+            "columnName": "model_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "consecutiveFailures",
+            "columnName": "consecutive_failures",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastFailureCode",
+            "columnName": "last_failure_code",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastFailureAtMs",
+            "columnName": "last_failure_at_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cooldownUntilMs",
+            "columnName": "cooldown_until_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dailyFailures",
+            "columnName": "daily_failures",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dailyFailuresDate",
+            "columnName": "daily_failures_date",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "model_id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "local_character_states",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `character_id` TEXT NOT NULL, `scope_id` TEXT NOT NULL, `data_json` TEXT NOT NULL, `updated_at` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "characterId",
+            "columnName": "character_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scopeId",
+            "columnName": "scope_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dataJson",
+            "columnName": "data_json",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_character_states_character_id_scope_id",
+            "unique": true,
+            "columnNames": [
+              "character_id",
+              "scope_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_local_character_states_character_id_scope_id` ON `${TABLE_NAME}` (`character_id`, `scope_id`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "local_relationship_states",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `character_id` TEXT NOT NULL, `target_id` TEXT NOT NULL, `data_json` TEXT NOT NULL, `updated_at` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "characterId",
+            "columnName": "character_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "targetId",
+            "columnName": "target_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dataJson",
+            "columnName": "data_json",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_relationship_states_character_id_target_id",
+            "unique": true,
+            "columnNames": [
+              "character_id",
+              "target_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_local_relationship_states_character_id_target_id` ON `${TABLE_NAME}` (`character_id`, `target_id`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "local_character_memories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `character_id` TEXT NOT NULL, `target_id` TEXT NOT NULL, `type` TEXT NOT NULL, `category` TEXT NOT NULL, `title` TEXT NOT NULL, `summary` TEXT NOT NULL, `content` TEXT NOT NULL, `importance` INTEGER NOT NULL, `emotion_impact` TEXT, `source_turn_id` TEXT, `created_at` TEXT NOT NULL, `expires_at` TEXT, `memory_path` TEXT, `version` INTEGER NOT NULL, `updated_at` TEXT, `conversation_id` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "characterId",
+            "columnName": "character_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "targetId",
+            "columnName": "target_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "summary",
+            "columnName": "summary",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "importance",
+            "columnName": "importance",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "emotionImpact",
+            "columnName": "emotion_impact",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "sourceTurnId",
+            "columnName": "source_turn_id",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "expiresAt",
+            "columnName": "expires_at",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "memoryPath",
+            "columnName": "memory_path",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "version",
+            "columnName": "version",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversation_id",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_character_memories_character_id",
+            "unique": false,
+            "columnNames": [
+              "character_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_character_memories_character_id` ON `${TABLE_NAME}` (`character_id`)"
+          },
+          {
+            "name": "index_local_character_memories_target_id",
+            "unique": false,
+            "columnNames": [
+              "target_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_character_memories_target_id` ON `${TABLE_NAME}` (`target_id`)"
+          },
+          {
+            "name": "index_local_character_memories_character_id_target_id",
+            "unique": false,
+            "columnNames": [
+              "character_id",
+              "target_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_character_memories_character_id_target_id` ON `${TABLE_NAME}` (`character_id`, `target_id`)"
+          },
+          {
+            "name": "index_local_character_memories_character_id_category",
+            "unique": false,
+            "columnNames": [
+              "character_id",
+              "category"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_character_memories_character_id_category` ON `${TABLE_NAME}` (`character_id`, `category`)"
+          },
+          {
+            "name": "index_local_character_memories_character_id_target_id_category",
+            "unique": false,
+            "columnNames": [
+              "character_id",
+              "target_id",
+              "category"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_character_memories_character_id_target_id_category` ON `${TABLE_NAME}` (`character_id`, `target_id`, `category`)"
+          },
+          {
+            "name": "index_local_character_memories_memory_path",
+            "unique": false,
+            "columnNames": [
+              "memory_path"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_character_memories_memory_path` ON `${TABLE_NAME}` (`memory_path`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "local_state_snapshots",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `session_id` TEXT NOT NULL, `character_id` TEXT NOT NULL, `target_id` TEXT NOT NULL, `timestamp` TEXT NOT NULL, `mood` TEXT NOT NULL, `mood_intensity` REAL NOT NULL, `energy` INTEGER NOT NULL, `affection` INTEGER NOT NULL, `trust` INTEGER NOT NULL, `familiarity` INTEGER NOT NULL, `dependency` INTEGER NOT NULL, `security` INTEGER NOT NULL, `jealousy` INTEGER NOT NULL, `quality_scores_json` TEXT, `trigger_type` TEXT NOT NULL, `user_message` TEXT, `assistant_message` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessionId",
+            "columnName": "session_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "characterId",
+            "columnName": "character_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "targetId",
+            "columnName": "target_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mood",
+            "columnName": "mood",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "moodIntensity",
+            "columnName": "mood_intensity",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "energy",
+            "columnName": "energy",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "affection",
+            "columnName": "affection",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "trust",
+            "columnName": "trust",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "familiarity",
+            "columnName": "familiarity",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dependency",
+            "columnName": "dependency",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "security",
+            "columnName": "security",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "jealousy",
+            "columnName": "jealousy",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "qualityScoresJson",
+            "columnName": "quality_scores_json",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "triggerType",
+            "columnName": "trigger_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userMessage",
+            "columnName": "user_message",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "assistantMessage",
+            "columnName": "assistant_message",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_state_snapshots_session_id",
+            "unique": false,
+            "columnNames": [
+              "session_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_state_snapshots_session_id` ON `${TABLE_NAME}` (`session_id`)"
+          },
+          {
+            "name": "index_local_state_snapshots_character_id_target_id",
+            "unique": false,
+            "columnNames": [
+              "character_id",
+              "target_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_state_snapshots_character_id_target_id` ON `${TABLE_NAME}` (`character_id`, `target_id`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "local_hooks",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `event` TEXT NOT NULL, `description` TEXT, `enabled` INTEGER NOT NULL, `scope` TEXT NOT NULL, `priority` INTEGER NOT NULL, `actions_json` TEXT NOT NULL, `conditions_json` TEXT, `permissions_json` TEXT, `timeout_ms` INTEGER NOT NULL, `max_retries` INTEGER NOT NULL, `trigger_mode` TEXT NOT NULL, `condition_logic` TEXT NOT NULL, `character_id` TEXT, `conversation_id` TEXT, `user_id` TEXT, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "event",
+            "columnName": "event",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "enabled",
+            "columnName": "enabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scope",
+            "columnName": "scope",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "priority",
+            "columnName": "priority",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "actionsJson",
+            "columnName": "actions_json",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conditionsJson",
+            "columnName": "conditions_json",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "permissionsJson",
+            "columnName": "permissions_json",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "timeoutMs",
+            "columnName": "timeout_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "maxRetries",
+            "columnName": "max_retries",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "triggerMode",
+            "columnName": "trigger_mode",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conditionLogic",
+            "columnName": "condition_logic",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "characterId",
+            "columnName": "character_id",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversation_id",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "user_id",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "local_hook_logs",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `hook_id` TEXT NOT NULL, `event_id` TEXT, `status` TEXT NOT NULL, `actions_executed` INTEGER NOT NULL, `error` TEXT, `duration_ms` INTEGER NOT NULL, `conversation_id` TEXT, `event_type` TEXT, `created_at` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hookId",
+            "columnName": "hook_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "eventId",
+            "columnName": "event_id",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "actionsExecuted",
+            "columnName": "actions_executed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "error",
+            "columnName": "error",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversation_id",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "eventType",
+            "columnName": "event_type",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_hook_logs_hook_id",
+            "unique": false,
+            "columnNames": [
+              "hook_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_hook_logs_hook_id` ON `${TABLE_NAME}` (`hook_id`)"
+          },
+          {
+            "name": "index_local_hook_logs_created_at",
+            "unique": false,
+            "columnNames": [
+              "created_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_hook_logs_created_at` ON `${TABLE_NAME}` (`created_at`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "local_tasks",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `kind` TEXT NOT NULL, `name` TEXT NOT NULL, `description` TEXT, `enabled` INTEGER NOT NULL, `trigger` TEXT NOT NULL, `config_json` TEXT, `target_session_id` TEXT, `prompt` TEXT, `created_at` TEXT NOT NULL, `last_run` TEXT, `next_run` TEXT, `status` TEXT NOT NULL, `last_error` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "kind",
+            "columnName": "kind",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "enabled",
+            "columnName": "enabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "trigger",
+            "columnName": "trigger",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "configJson",
+            "columnName": "config_json",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "targetSessionId",
+            "columnName": "target_session_id",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "prompt",
+            "columnName": "prompt",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastRun",
+            "columnName": "last_run",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "nextRun",
+            "columnName": "next_run",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastError",
+            "columnName": "last_error",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "local_workflows",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `description` TEXT, `enabled` INTEGER NOT NULL, `trigger` TEXT NOT NULL, `config_json` TEXT, `created_at` TEXT NOT NULL, `session_id` TEXT, `last_run` TEXT, `next_run` TEXT, `status` TEXT NOT NULL, `last_error` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "enabled",
+            "columnName": "enabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "trigger",
+            "columnName": "trigger",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "configJson",
+            "columnName": "config_json",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessionId",
+            "columnName": "session_id",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "lastRun",
+            "columnName": "last_run",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "nextRun",
+            "columnName": "next_run",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastError",
+            "columnName": "last_error",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "local_skills",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `description` TEXT, `aliases_json` TEXT NOT NULL, `enabled` INTEGER NOT NULL, `parameters_json` TEXT, `created_at` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "aliasesJson",
+            "columnName": "aliases_json",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "enabled",
+            "columnName": "enabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "parametersJson",
+            "columnName": "parameters_json",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "local_tools",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `description` TEXT, `enabled` INTEGER NOT NULL, `parameters_json` TEXT, `implementation_json` TEXT, `builtin` INTEGER NOT NULL, `created_at` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "enabled",
+            "columnName": "enabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "parametersJson",
+            "columnName": "parameters_json",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "implementationJson",
+            "columnName": "implementation_json",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "builtin",
+            "columnName": "builtin",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "local_mcp_servers",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `transport` TEXT NOT NULL, `description` TEXT, `enabled` INTEGER NOT NULL, `auto_connect` INTEGER NOT NULL, `connected` INTEGER NOT NULL, `tool_count` INTEGER NOT NULL, `url` TEXT, `headers_json` TEXT, `command` TEXT, `args_json` TEXT, `env_json` TEXT, `builtin` INTEGER NOT NULL, `created_at` TEXT NOT NULL, `last_connected_at` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "transport",
+            "columnName": "transport",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "enabled",
+            "columnName": "enabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "autoConnect",
+            "columnName": "auto_connect",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "connected",
+            "columnName": "connected",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "toolCount",
+            "columnName": "tool_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "headersJson",
+            "columnName": "headers_json",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "command",
+            "columnName": "command",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "argsJson",
+            "columnName": "args_json",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "envJson",
+            "columnName": "env_json",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "builtin",
+            "columnName": "builtin",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastConnectedAt",
+            "columnName": "last_connected_at",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "local_api_keys",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `key` TEXT NOT NULL, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "key",
+            "columnName": "key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "local_message_favorites",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `session_id` TEXT NOT NULL, `title` TEXT NOT NULL, `message_ids_json` TEXT NOT NULL, `created_at` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessionId",
+            "columnName": "session_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "messageIdsJson",
+            "columnName": "message_ids_json",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_message_favorites_session_id",
+            "unique": false,
+            "columnNames": [
+              "session_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_message_favorites_session_id` ON `${TABLE_NAME}` (`session_id`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "local_oauth_accounts",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `provider` TEXT NOT NULL, `label` TEXT NOT NULL, `encrypted_credentials` TEXT NOT NULL, `metadata_json` TEXT NOT NULL, `status` TEXT NOT NULL, `expires_at` INTEGER, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "provider",
+            "columnName": "provider",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "label",
+            "columnName": "label",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "encryptedCredentials",
+            "columnName": "encrypted_credentials",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "metadataJson",
+            "columnName": "metadata_json",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "expiresAt",
+            "columnName": "expires_at",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_oauth_accounts_provider",
+            "unique": false,
+            "columnNames": [
+              "provider"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_oauth_accounts_provider` ON `${TABLE_NAME}` (`provider`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "local_knowledge_documents",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `title` TEXT NOT NULL, `content` TEXT NOT NULL, `source` TEXT, `tags_json` TEXT NOT NULL, `metadata_json` TEXT, `indexed` INTEGER NOT NULL, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "tagsJson",
+            "columnName": "tags_json",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "metadataJson",
+            "columnName": "metadata_json",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "indexed",
+            "columnName": "indexed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "local_knowledge_chunks",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `document_id` TEXT NOT NULL, `chunk_index` INTEGER NOT NULL, `content` TEXT NOT NULL, `embedding_json` TEXT, `char_offset` INTEGER NOT NULL, `char_end` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`document_id`) REFERENCES `local_knowledge_documents`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "documentId",
+            "columnName": "document_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chunkIndex",
+            "columnName": "chunk_index",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "embeddingJson",
+            "columnName": "embedding_json",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "charOffset",
+            "columnName": "char_offset",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "charEnd",
+            "columnName": "char_end",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_knowledge_chunks_document_id",
+            "unique": false,
+            "columnNames": [
+              "document_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_knowledge_chunks_document_id` ON `${TABLE_NAME}` (`document_id`)"
+          },
+          {
+            "name": "index_local_knowledge_chunks_document_id_chunk_index",
+            "unique": true,
+            "columnNames": [
+              "document_id",
+              "chunk_index"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_local_knowledge_chunks_document_id_chunk_index` ON `${TABLE_NAME}` (`document_id`, `chunk_index`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "local_knowledge_documents",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "document_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "routing_decision_logs",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `session_id` TEXT NOT NULL, `created_at` TEXT NOT NULL, `decision_json` TEXT NOT NULL, `selected_model_id` TEXT NOT NULL, `selected_model_name` TEXT NOT NULL, `estimated_cost_usd` REAL NOT NULL, `actual_cost_usd` REAL, `actual_duration_ms` INTEGER, `actual_ttft_ms` INTEGER, `success` INTEGER NOT NULL, `failure_reason` TEXT, `quality_score` INTEGER NOT NULL, `is_ab_test` INTEGER NOT NULL, `ab_test_group` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessionId",
+            "columnName": "session_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "decisionJson",
+            "columnName": "decision_json",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "selectedModelId",
+            "columnName": "selected_model_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "selectedModelName",
+            "columnName": "selected_model_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "estimatedCostUsd",
+            "columnName": "estimated_cost_usd",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "actualCostUsd",
+            "columnName": "actual_cost_usd",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "actualDurationMs",
+            "columnName": "actual_duration_ms",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "actualTtftMs",
+            "columnName": "actual_ttft_ms",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "success",
+            "columnName": "success",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "failureReason",
+            "columnName": "failure_reason",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "qualityScore",
+            "columnName": "quality_score",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isAbTest",
+            "columnName": "is_ab_test",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "abTestGroup",
+            "columnName": "ab_test_group",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_routing_decision_logs_session_id",
+            "unique": false,
+            "columnNames": [
+              "session_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_routing_decision_logs_session_id` ON `${TABLE_NAME}` (`session_id`)"
+          },
+          {
+            "name": "index_routing_decision_logs_created_at",
+            "unique": false,
+            "columnNames": [
+              "created_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_routing_decision_logs_created_at` ON `${TABLE_NAME}` (`created_at`)"
+          },
+          {
+            "name": "index_routing_decision_logs_selected_model_id",
+            "unique": false,
+            "columnNames": [
+              "selected_model_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_routing_decision_logs_selected_model_id` ON `${TABLE_NAME}` (`selected_model_id`)"
+          }
+        ],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '68be262d3181f330585d2ef691ec4ded')"
+    ]
+  }
+}

--- a/app/src/main/kotlin/com/nekobot/app/data/local/LocalRepository.kt
+++ b/app/src/main/kotlin/com/nekobot/app/data/local/LocalRepository.kt
@@ -2026,7 +2026,9 @@ class LocalRepository(
             createdAt = now,
             model = model,
             inputTokens = inputTokens,
-            outputTokens = outputTokens
+            outputTokens = outputTokens,
+            // 生成耗时（毫秒）：气泡下方 tok/s 与 token 用量记录共用同一来源。
+            durationMs = durationMs
         )
         messageDao.upsert(msg)
         val session = sessionDao.getById(sessionId)
@@ -4827,7 +4829,8 @@ class LocalRepository(
                             createdAt = now,
                             model = modelDisplayName ?: activeModel.name,
                             inputTokens = usage.inputTokens,
-                            outputTokens = usage.outputTokens
+                            outputTokens = usage.outputTokens,
+                            durationMs = durationMs
                         )
                         messageDao.upsert(msg)
                         // 如果删除旧开场白后消息表为空，需要把新消息插入到最前面
@@ -8563,6 +8566,7 @@ ${AiOutputLanguage.directive()}
         audioUrl = audioUrl,
         inputTokens = inputTokens,
         outputTokens = outputTokens,
+        durationMs = durationMs,
         // 合并 input+output 作为总 token 数，供 UI 统计使用
         tokens = listOfNotNull(inputTokens, outputTokens).takeIf { it.size == 2 }?.sum(),
         source = source,

--- a/app/src/main/kotlin/com/nekobot/app/data/local/ai/AIPipeline.kt
+++ b/app/src/main/kotlin/com/nekobot/app/data/local/ai/AIPipeline.kt
@@ -593,8 +593,11 @@ class AIPipeline {
             return
         }
         val modelCall = callbacks.buildModelCall(ctx, emptyList())
+        val callStartNanos = System.nanoTime()
         try {
             val response = modelCall(ctx.messages, ctx.shouldStop())
+            // 生成耗时：无工具的单次调用同样写入 metadata，供消息持久化与 tok/s 使用
+            ctx.metadata["duration_ms"] = (System.nanoTime() - callStartNanos) / 1_000_000.0
             if (ctx.shouldStop()) {
                 markStopped(ctx)
                 return
@@ -727,6 +730,9 @@ class AIPipeline {
         try {
             val executionResult = runToolLoopSession(session)
             val loopResult = executionResult.loopResult
+            // 工具循环内所有模型调用的累计耗时写入 metadata，供消息持久化与 token 用量记录共用
+            // （无工具路径由 runStreaming 写同一个 key）。两者都排除工具执行时间，语义一致。
+            loopResult.modelCallDurationMs?.let { ctx.metadata["duration_ms"] = it }
             ctx.finalReasoning = loopResult.finalReasoning
 
             @Suppress("UNCHECKED_CAST")

--- a/app/src/main/kotlin/com/nekobot/app/data/local/ai/AgentService.kt
+++ b/app/src/main/kotlin/com/nekobot/app/data/local/ai/AgentService.kt
@@ -231,7 +231,14 @@ data class ToolLoopResult(
     val modelName: String = "",
     /** 实际模型标识（如 gpt-4o），用于排行榜按模型聚合 */
     val modelActualName: String = "",
-    val failoverEvents: List<Map<String, Any>> = emptyList()
+    val failoverEvents: List<Map<String, Any>> = emptyList(),
+    /**
+     * 本轮所有模型调用的总耗时（毫秒），不含工具执行时间。
+     *
+     * 与 [usage] 中累计的输出 token 配对：两者都覆盖循环内的每一次模型调用，
+     * 因此「输出 token ÷ 该耗时」即为本轮真实的模型生成速度（tok/s）。
+     */
+    val modelCallDurationMs: Double? = null
 )
 
 /** 工具执行结果（含循环结果和准备好的消息） */
@@ -725,6 +732,9 @@ suspend fun runToolCallLoop(
     var currentModelActualName = ""
     val allFailoverEvents = mutableListOf<Map<String, Any>>()
     val loopGuard = AgentToolLoopGuard()
+    // 本轮模型调用次数与累计耗时（毫秒）：与 usage 累计的输出 token 配对，用于 tok/s 统计
+    var modelCallCount = 0
+    var modelCallDurationMs = 0.0
 
     fun result(
         finalContentArg: String? = null,
@@ -743,7 +753,8 @@ suspend fun runToolCallLoop(
         modelId = currentModelId,
         modelName = currentModelName,
         modelActualName = currentModelActualName,
-        failoverEvents = allFailoverEvents.toList()
+        failoverEvents = allFailoverEvents.toList(),
+        modelCallDurationMs = modelCallDurationMs.takeIf { modelCallCount > 0 }
     )
 
     for (iteration in 0 until maxIterations) {
@@ -778,6 +789,7 @@ suspend fun runToolCallLoop(
             )
         }
 
+        val callStartNanos = System.nanoTime()
         val response = try {
             modelCall(toolMessages.map { it.toMap() }, shouldStop())
         } catch (e: ToolLoopExit) {
@@ -787,6 +799,10 @@ suspend fun runToolCallLoop(
                 return result(stopped = true, iterations = iteration + 1)
             }
             throw ToolLoopModelError(e, iteration)
+        } finally {
+            // 每次迭代都累计：循环结束后得到本轮全部模型调用的生成耗时，不含工具执行时间
+            modelCallDurationMs += (System.nanoTime() - callStartNanos) / 1_000_000.0
+            modelCallCount += 1
         }
         if (shouldStop()) {
             return result(stopped = true, iterations = iteration + 1)

--- a/app/src/main/kotlin/com/nekobot/app/data/local/ai/LocalPipelineCallbacks.kt
+++ b/app/src/main/kotlin/com/nekobot/app/data/local/ai/LocalPipelineCallbacks.kt
@@ -529,6 +529,11 @@ internal class LocalPipelineCallbacks(
                 ?: ctx.finalReasoning
         }
 
+        // 从 Pipeline metadata 提取首字延迟与生成耗时，消息持久化、路由日志和 Token 统计共用。
+        // 流式路径由那次模型调用写入，Agent 工具循环由其内部累计的全部模型调用写入（都不含工具执行时间）。
+        val durationMs = (ctx.metadata["duration_ms"] as? Number)?.toDouble()
+        val ttftMs = (ctx.metadata["ttft_ms"] as? Number)?.toDouble()
+
         // 保存到 Room（同步执行，因为已在 IO 线程）
         kotlinx.coroutines.runBlocking {
             messageDao.upsert(LocalMessageEntity(
@@ -544,7 +549,9 @@ internal class LocalPipelineCallbacks(
                 createdAt = com.nekobot.app.data.local.LocalRepository.nowIsoStatic(),
                 toolCallHistory = toolCallHistoryJson,
                 source = assistantSource,
-                reasoningContent = reasoningContent.takeIf(String::isNotBlank)
+                reasoningContent = reasoningContent.takeIf(String::isNotBlank),
+                // 生成耗时（毫秒）：气泡下方 tok/s 与 token 用量记录共用同一来源。
+                durationMs = durationMs
             ))
 
             persistPendingGeneratedImages(messageId)
@@ -593,9 +600,6 @@ internal class LocalPipelineCallbacks(
             }
         }
 
-        // 从 Pipeline metadata 提取首字延迟与总耗时，路由日志和 Token 统计共用。
-        val durationMs = (ctx.metadata["duration_ms"] as? Number)?.toDouble()
-        val ttftMs = (ctx.metadata["ttft_ms"] as? Number)?.toDouble()
         val priceModel = modelQueue.firstOrNull { model ->
             model.model == actualModelName || model.name == modelName
         } ?: activeModel

--- a/app/src/main/kotlin/com/nekobot/app/data/local/db/Entities.kt
+++ b/app/src/main/kotlin/com/nekobot/app/data/local/db/Entities.kt
@@ -118,7 +118,14 @@ data class LocalMessageEntity(
     /** RAG 引用来源 JSON（KnowledgeSearchResult 列表序列化） */
     @ColumnInfo(name = "knowledge_citations") val knowledgeCitations: String? = null,
     /** 路由决策日志 ID，关联 routing_decision_logs 表 */
-    @ColumnInfo(name = "routing_decision_id") val routingDecisionId: String? = null
+    @ColumnInfo(name = "routing_decision_id") val routingDecisionId: String? = null,
+    /**
+     * 本条回复的生成耗时（毫秒）：生成这条回复所耗的模型调用时间之和，不含工具执行时间。
+     *
+     * 本地生成路径写入，供 UI 在气泡下方按「输出 token ÷ 耗时」计算 tok/s；
+     * 服务端消息与导入的历史消息为 null，此时不展示速度。
+     */
+    @ColumnInfo(name = "duration_ms") val durationMs: Double? = null
 )
 
 /**

--- a/app/src/main/kotlin/com/nekobot/app/data/local/db/NekobotDatabase.kt
+++ b/app/src/main/kotlin/com/nekobot/app/data/local/db/NekobotDatabase.kt
@@ -41,7 +41,7 @@ import androidx.sqlite.db.SupportSQLiteDatabase
         LocalKnowledgeChunkEntity::class,
         RoutingDecisionLogEntity::class
     ],
-    version = 38,
+    version = 39,
     exportSchema = true
 )
 abstract class NekobotDatabase : RoomDatabase() {
@@ -778,6 +778,13 @@ abstract class NekobotDatabase : RoomDatabase() {
             }
         }
 
+        /** v38 → v39：消息生成耗时（毫秒），用于 AI 气泡下方展示 tok/s。 */
+        val MIGRATION_38_39 = object : Migration(38, 39) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("ALTER TABLE local_messages ADD COLUMN duration_ms REAL")
+            }
+        }
+
         /**
          * 完整迁移链同时供生产数据库构建和迁移回归测试使用。
          * 新版本必须把迁移追加到这里；缺少迁移时直接失败，绝不静默清空用户数据。
@@ -792,7 +799,7 @@ abstract class NekobotDatabase : RoomDatabase() {
             MIGRATION_25_26, MIGRATION_26_27, MIGRATION_27_28, MIGRATION_28_29,
             MIGRATION_29_30, MIGRATION_30_31, MIGRATION_31_32, MIGRATION_32_33,
             MIGRATION_33_34, MIGRATION_34_35, MIGRATION_35_36, MIGRATION_36_37,
-            MIGRATION_37_38
+            MIGRATION_37_38, MIGRATION_38_39
         )
 
         fun get(context: Context): NekobotDatabase =

--- a/app/src/main/kotlin/com/nekobot/app/data/model/Models.kt
+++ b/app/src/main/kotlin/com/nekobot/app/data/model/Models.kt
@@ -228,6 +228,12 @@ data class Message(
     val tokens: Int? = null,
     @SerializedName("input_tokens") val inputTokens: Int? = null,
     @SerializedName("output_tokens") val outputTokens: Int? = null,
+    /**
+     * 本条回复的生成耗时（毫秒）：生成这条回复所耗的模型调用时间之和，不含工具执行时间。
+     * 本地生成路径持久化该字段，服务端消息可能为空；
+     * UI 用它和 [outputTokens] 一起换算气泡下方的 tok/s。
+     */
+    @SerializedName("duration_ms") val durationMs: Double? = null,
     val model: String? = null,
     val filtered: Boolean? = null,
     /** 本地持久化消息来源；Agent 上下文摘要使用它保存压缩边界。 */

--- a/app/src/main/kotlin/com/nekobot/app/ui/screens/chat/ChatScreen.kt
+++ b/app/src/main/kotlin/com/nekobot/app/ui/screens/chat/ChatScreen.kt
@@ -3152,8 +3152,9 @@ private fun MessageBubble(
                 )
             }
 
-            // 元信息：时间（精简到分钟）/ token 数 + 操作按钮，AI 气泡合并到同一行
+            // 元信息：时间（精简到分钟）/ token 数 / 生成速度 + 操作按钮，AI 气泡合并到同一行
             val compactTs = compactTime(message.timestamp)
+            val tokenSpeed = formatTokenSpeed(message.outputTokens, message.durationMs)
             Row(
                 verticalAlignment = Alignment.CenterVertically,
                 modifier = Modifier
@@ -3168,6 +3169,11 @@ private fun MessageBubble(
                     message.tokens?.let { tokens ->
                         if (compactTs != null) Spacer(Modifier.width(6.dp))
                         Text("${formatTokenCount(tokens)} tok", style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                    }
+                    // 耗费 token 旁边补上生成速度（本地生成的消息才有耗时数据）
+                    tokenSpeed?.let { speed ->
+                        if (compactTs != null || message.tokens != null) Spacer(Modifier.width(6.dp))
+                        Text(speed, style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
                     }
                 }
                 // 用户气泡：复制按钮放最右边；AI 气泡：三个操作按钮放最右边

--- a/app/src/main/kotlin/com/nekobot/app/ui/screens/chat/ChatValueFormatter.kt
+++ b/app/src/main/kotlin/com/nekobot/app/ui/screens/chat/ChatValueFormatter.kt
@@ -1,6 +1,7 @@
 package com.nekobot.app.ui.screens.chat
 
 import com.google.gson.GsonBuilder
+import kotlin.math.roundToInt
 
 /** 将工具参数和结果格式化为适合用户阅读的 JSON，保留原始符号而不是 HTML 转义。 */
 internal fun formatJsonForDisplay(value: Any): String {
@@ -12,6 +13,30 @@ internal fun formatJsonForDisplay(value: Any): String {
             .toJson(value)
     }.getOrElse { value.toString() }
 }
+
+/**
+ * 生成速度（tok/s）：输出 token ÷ 生成耗时，用于「N tok」旁展示本条回复的生成速度。
+ *
+ * 与 token 数使用同一行、同一字号，因此这里连单位一起返回（如 `34.5 tok/s`）。
+ * 以下情况返回 null（不展示）：
+ * - 缺少输出 token 或耗时（服务端消息、导入的历史消息、估算失败的回复）
+ * - 耗时样本过短（< [MIN_TOKEN_SPEED_SAMPLE_MS] 毫秒）：换算出来的速度没有参考价值
+ */
+internal fun formatTokenSpeed(outputTokens: Int?, durationMs: Double?): String? {
+    val tokens = outputTokens ?: return null
+    val duration = durationMs ?: return null
+    if (tokens <= 0 || duration < MIN_TOKEN_SPEED_SAMPLE_MS) return null
+    val speed = tokens * 1000.0 / duration
+    val text = if (speed >= 100) {
+        speed.roundToInt().toString()
+    } else {
+        String.format(java.util.Locale.US, "%.1f", speed)
+    }
+    return "$text tok/s"
+}
+
+/** tok/s 的最短采样时长：低于该耗时时四舍五入误差会明显放大速度值。 */
+private const val MIN_TOKEN_SPEED_SAMPLE_MS = 100.0
 
 /**
  * 将 token 数量格式化为易读的紧凑写法：

--- a/app/src/test/kotlin/com/nekobot/app/data/local/ai/LocalAgentToolingTest.kt
+++ b/app/src/test/kotlin/com/nekobot/app/data/local/ai/LocalAgentToolingTest.kt
@@ -750,6 +750,57 @@ class LocalAgentToolingTest {
     }
 
     @Test
+    fun toolLoopAccumulatesModelCallDurationAcrossIterations() = runBlocking {
+        var modelCalls = 0
+        val result = runToolCallLoop(
+            initialMessages = listOf(mapOf("role" to "user", "content" to "统计生成速度")),
+            modelCall = { _, _ ->
+                modelCalls += 1
+                Thread.sleep(40)
+                if (modelCalls == 1) {
+                    mapOf(
+                        "content" to "",
+                        "finish_reason" to "tool_calls",
+                        "usage" to mapOf("completion" to 10),
+                        "tool_calls" to listOf(
+                            mapOf(
+                                "id" to "call-1",
+                                "name" to "get_date_time",
+                                "arguments" to emptyMap<String, Any>()
+                            )
+                        )
+                    )
+                } else {
+                    mapOf(
+                        "content" to "完成",
+                        "finish_reason" to "stop",
+                        "usage" to mapOf("completion" to 20)
+                    )
+                }
+            },
+            toolExecutor = { _, _, _, _ -> mapOf("success" to true) }
+        )
+
+        assertEquals(2, modelCalls)
+        assertEquals("完成", result.finalContent)
+        assertEquals(30, result.usage["completion"] as? Int)
+        // 两次调用各约 40ms：耗时必须累计（而不是只记最后一次），否则 tok/s 会被高估
+        assertTrue((result.modelCallDurationMs ?: 0.0) >= 70.0)
+    }
+
+    @Test
+    fun toolLoopOmitsModelCallDurationWhenModelIsNeverCalled() = runBlocking {
+        val result = runToolCallLoop(
+            initialMessages = listOf(mapOf("role" to "user", "content" to "已停止")),
+            modelCall = { _, _ -> throw AssertionError("不应调用模型") },
+            toolExecutor = { _, _, _, _ -> emptyMap() },
+            shouldStop = { true }
+        )
+
+        assertEquals(null, result.modelCallDurationMs)
+    }
+
+    @Test
     fun workspaceExtractEpubCreatesOrderedTxtAndReturnsCanonicalPath() = runBlocking {
         val root = Files.createTempDirectory("nekobot-agent-epub").toFile()
         try {

--- a/app/src/test/kotlin/com/nekobot/app/data/local/db/NekobotDatabaseMigrationChainTest.kt
+++ b/app/src/test/kotlin/com/nekobot/app/data/local/db/NekobotDatabaseMigrationChainTest.kt
@@ -14,6 +14,6 @@ class NekobotDatabaseMigrationChainTest {
         migrations.zipWithNext().forEach { (current, next) ->
             assertEquals(current.endVersion, next.startVersion)
         }
-        assertEquals(38, migrations.last().endVersion)
+        assertEquals(39, migrations.last().endVersion)
     }
 }

--- a/app/src/test/kotlin/com/nekobot/app/ui/screens/chat/ChatValueFormatterTest.kt
+++ b/app/src/test/kotlin/com/nekobot/app/ui/screens/chat/ChatValueFormatterTest.kt
@@ -41,4 +41,28 @@ class ChatValueFormatterTest {
         assertEquals("12M", formatTokenCount(12_000_000))
         assertEquals("350M", formatTokenCount(350_000_000))
     }
+
+    @Test
+    fun formatTokenSpeed_dividesOutputTokensByGenerationTime() {
+        // 100 token / 2000ms = 50 tok/s
+        assertEquals("50.0 tok/s", formatTokenSpeed(100, 2_000.0))
+        // 输出很短时保留一位小数，便于区分快慢
+        assertEquals("8.3 tok/s", formatTokenSpeed(50, 6_000.0))
+    }
+
+    @Test
+    fun formatTokenSpeed_dropsFractionFromThreeDigits() {
+        assertEquals("120 tok/s", formatTokenSpeed(600, 5_000.0))
+    }
+
+    @Test
+    fun formatTokenSpeed_hidesWhenSampleIsMissingOrTooShort() {
+        // 服务端消息、导入的历史消息没有耗时
+        assertEquals(null, formatTokenSpeed(120, null))
+        // 没有输出 token（例如只有工具调用、或用量缺失）
+        assertEquals(null, formatTokenSpeed(null, 3_000.0))
+        assertEquals(null, formatTokenSpeed(0, 3_000.0))
+        // 采样过短：换算结果没有参考价值
+        assertEquals(null, formatTokenSpeed(3, 20.0))
+    }
 }


### PR DESCRIPTION
## 需求

Agent 会话里，一轮对话结束后，AI 气泡下方的元信息行已经展示时间与「N tok」，需要在 token 数旁再补上生成速度 **tok/s**。

## 实现

**展示（UI）**

- `MessageBubble` 元信息行新增一段文本，显示形如 `12.3k tok · 34.5 tok/s`，与 token 数同一行、同一字号：
  - 耗时缺失（服务端消息、导入的历史消息、用量估算失败的回复）时不展示，不影响原有 token 展示；
  - 采样时间 < 100ms 时也不展示，避免短回复换算出无意义的速度；
  - 速度 < 100 保留一位小数，≥ 100 取整（与 `formatTokenCount` 的风格一致）。
- 新增 `formatTokenSpeed(outputTokens, durationMs)`（`ChatValueFormatter.kt`），纯函数，便于单测。

**数据（生成耗时）**

此前 Agent 路径完全没有耗时数据：`runStreaming` 只在「无工具」路径写 `metadata["duration_ms"]`，而 Agent 走的是 `runToolCallLoop` 工具循环，该 key 为空，因此 token 用量记录里的「耗时」对 Agent 会话也一直是空的。

- `runToolCallLoop` 现在累计本轮**每一次**模型调用的耗时（`ToolLoopResult.modelCallDurationMs`），`finally` 中累加，不含工具执行时间；
- `AIPipeline.runToolLoop` 把它写入 `ctx.metadata["duration_ms"]`，与无工具流式路径写入同一个 key，语义一致（都不含工具执行时间）；
- `runSimple`（无工具、非流式的单次调用）同样写入耗时；
- 该数值同时会被既有的 token 用量记录 / 路由决策日志复用，Agent 会话的「耗时」字段顺带补上了。

**持久化**

- `local_messages` 新增 `duration_ms REAL` 列；DB 版本 38 → 39，新增 `MIGRATION_38_39`（`ALTER TABLE ... ADD COLUMN`）并加入 `ALL_MIGRATIONS`；
- `LocalMessageEntity` / `Message` 新增 `durationMs`，`toMessage()` 透传到 UI；
- 写入位置：`LocalPipelineCallbacks.saveAssistantMessage`（Pipeline 主路径）、`LocalRepository.addAssistantMessage`、首条开场白的流式生成路径。

> 语义：`duration_ms` = 生成这条回复所耗的模型调用时间之和（Agent 轮次含工具循环内每一次模型调用），不含工具执行时间；与消息上的 `output_tokens`（同一批调用的输出 token 之和）配对，因此「输出 token ÷ 耗时」得到的正是本轮的平均生成速度。

## 测试

- `ChatValueFormatterTest`：`formatTokenSpeed` 的换算、取整策略与各种不展示场景；
- `LocalAgentToolingTest`：工具循环跨迭代累计耗时（两次调用各约 40ms，断言 ≥ 70ms，防止退化成「只记最后一次」而高估 tok/s）；未调用模型时耗时为 null。

## 验证情况

- 本机已执行 `./gradlew.bat --no-daemon --console=plain clean :app:testDebugUnitTest`：Kotlin 编译与单元测试全部通过（含新增的 `formatTokenSpeed` 用例、工具循环耗时累计用例、迁移链版本断言）。
- `app/schemas/com.nekobot.app.data.local.db.NekobotDatabase/39.json` 已由本机 KSP 构建导出（`./gradlew :app:kspDebugKotlin`）并随本 PR 提交，schema 中 `local_messages` 含 `duration_ms` REAL 列。

## 影响面

- 仅本地生成路径有耗时数据，因此该速度标签实际只在本地模式（Agent / 角色会话）出现；服务端模式消息若无 `duration_ms` 字段则自动不展示（若服务端后续返回该字段，UI 无需改动即可生效）。
